### PR TITLE
Don't use shell=True so it works in virtualenv

### DIFF
--- a/Python/tdw/release/pypi.py
+++ b/Python/tdw/release/pypi.py
@@ -41,7 +41,7 @@ class PyPi:
         """
 
         # Get an error from  PyPi which will list all available versions.
-        p = Popen(["pip3", "install", "tdw=="], stderr=PIPE, shell=True, stdout=PIPE)
+        p = Popen(["pip3", "install", "tdw=="], stderr=PIPE, stdout=PIPE)
         p.wait()
         stdout, stderr = p.communicate()
         # From the list of available versions, get the last one (the most recent).
@@ -74,7 +74,7 @@ class PyPi:
         """
 
         # Get info on the tdw module.
-        p = check_output(["pip3", "show", "tdw"], shell=True).decode("utf-8")
+        p = check_output(["pip3", "show", "tdw"]).decode("utf-8")
         # Get the version from the output.
         v = re.search(r"Version: (.*)", p, flags=re.MULTILINE).group(1).strip()
 


### PR DESCRIPTION
I'm following the "getting started" guide, but don't want to `sudo pip install` things, so am running this in a virtualenv. It doesn't work because using `shell=True`, removing it works. I don't think you actually need `shell=True` as you're just executing a command, not using redirects/pipes/etc. in the command itself.

Also, a second problem that I'm not solving in this PR, the binary it created didn't have execute rights:

```
><((("> python test.py
Your installed tdw Python module is up to date with PyPi.
Couldn't find build at /home/beyer/tdw_build/TDW/TDW.x86_64
Downloading now...
Downloaded the build.
Saved the .zip file.
Extracted the .zip file to: /home/beyer/tdw_build
Deleted the .zip file.
Traceback (most recent call last):
  File "test.py", line 3, in <module>
    c = Controller()
  File "/home/beyer/academic/tdw/env/lib/python3.8/site-packages/tdw/controller.py", line 45, in __init__
    Controller.launch_build(display)
  File "/home/beyer/academic/tdw/env/lib/python3.8/site-packages/tdw/controller.py", line 305, in launch_build
    Popen(str(Build.BUILD_PATH.resolve()))
  File "/usr/lib/python3.8/subprocess.py", line 854, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.8/subprocess.py", line 1702, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
PermissionError: [Errno 13] Permission denied: '/home/beyer/tdw_build/TDW/TDW.x86_64'
><((("> mkdir ~/tdw_build
mkdir: cannot create directory ‘/home/beyer/tdw_build’: File exists
><((("> ll ~/tdw_build
total 4.0K
drwxr-xr-x 3 beyer beyer 4.0K Jul 26 18:06 TDW/
><((("> ll ~/tdw_build/TDW/
total 29M
drwxr-xr-x 6 beyer beyer 4.0K Jul 26 18:06 TDW_Data/
-rw-r--r-- 1 beyer beyer  29M Jul 26 18:06 TDW.x86_64
><((("> chmod +x ~/tdw_build/TDW/TDW.x86_64 
><((("> python test.py
Your installed tdw Python module is up to date with PyPi.
Found path: /home/beyer/tdw_build/TDW/TDW.x86_64
Build version 1.6.1
Unity Engine 2019.2.21f1
Python tdw module version 1.6.1
Everything is OK!
```