### PR TITLE
Use shell=True when launching the build in Windows

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -6,6 +6,10 @@
 
 ### `tdw` module
 
+#### `Controller`
+
+- Fixed: Build doesn't launch in Windows.
+
 #### `AssetBundleCreator`
 
 - Fixed: `AssetBundleCreator.get_local_urls()` doesn't add the OS X URL.

--- a/Python/tdw/controller.py
+++ b/Python/tdw/controller.py
@@ -311,7 +311,10 @@ class Controller(object):
             success = True
         # Launch the build.
         if success:
-            Popen(str(Build.BUILD_PATH.resolve()))
+            if system() == "Windows":
+                Popen(str(Build.BUILD_PATH.resolve()), shell=True)
+            else:
+                Popen(str(Build.BUILD_PATH.resolve()))
 
     def _check_build_version(self, version: str = __version__, build_version: str = None) -> None:
         """


### PR DESCRIPTION
How to test:

1. `git fetch`
2. `git checkout controller_popen_shell`
3. `cd Python/example_controllers`
4. `py -3 minimal.py`