### PR TITLE
Revert popen shell

### DIFF
--- a/Python/tdw/controller.py
+++ b/Python/tdw/controller.py
@@ -311,10 +311,7 @@ class Controller(object):
             success = True
         # Launch the build.
         if success:
-            if system() == "Windows":
-                Popen(str(Build.BUILD_PATH.resolve()), shell=True)
-            else:
-                Popen(str(Build.BUILD_PATH.resolve()))
+            Popen(str(Build.BUILD_PATH.resolve()))
 
     def _check_build_version(self, version: str = __version__, build_version: str = None) -> None:
         """

--- a/Python/tdw/controller.py
+++ b/Python/tdw/controller.py
@@ -311,7 +311,7 @@ class Controller(object):
             success = True
         # Launch the build.
         if success:
-            Popen(str(Build.BUILD_PATH.resolve()))
+            Popen([str(Build.BUILD_PATH.resolve())])
 
     def _check_build_version(self, version: str = __version__, build_version: str = None) -> None:
         """


### PR DESCRIPTION
Fixed a bug where launching TDW via Popen in Windows resulted in a WinError 193.

Solution: Encapsulate launch args in a list.