### PR TITLE
Position marker colliders

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -4,6 +4,12 @@
 
 To upgrade from TDW v1.6 to v1.7, read [this guide](Documentation/v1.6_to_v1.7).
 
+## v1.7.3
+
+### Build
+
+- Fixed: The objects created by `add_position_marker` initially have colliders, potentially causing physics interactions.
+
 ## v1.7.2
 
 ### Command API


### PR DESCRIPTION
### Build

- Fixed: The objects created by `add_position_marker` initially have colliders, potentially causing physics interactions.