### PR TITLE
Added functions for hashing and un-hashing colors

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -6,6 +6,13 @@ To upgrade from TDW v1.6 to v1.7, read [this guide](Documentation/v1.6_to_v1.7).
 
 ## v1.7.3
 
+### `tdw` module
+
+#### `TDWUtils`
+
+- Added: `color_to_hashable()`. Convert a color to a hashable integer.
+- Added: `hashable_to_color()`. Convert a hashable integer to a color.
+
 ### Model Library
 
 - Added to `models_core.json`:

--- a/Documentation/python/tdw_utils.md
+++ b/Documentation/python/tdw_utils.md
@@ -437,7 +437,7 @@ _This is a static function._
 | --- | --- |
 | hashable | A hashable integer representing an RGB color. |
 
-_Returns:_  A color as a numpy array of integers between 0 and 255: [r, g, b]
+_Returns:_  A color as a numpy array of integers between 0 and 255: `[r, g, b]`
 
 ***
 

--- a/Documentation/python/tdw_utils.md
+++ b/Documentation/python/tdw_utils.md
@@ -415,6 +415,32 @@ _Returns:_  An array of Flex particle forces encoded in base64.
 
 ***
 
+#### `color_to_hashable(color: Union[np.array, Tuple[int, int, int]]) -> int`
+
+_This is a static function._
+
+
+| Parameter | Description |
+| --- | --- |
+| color | The color as an RGB array or tuple, where each value is between 0 and 255. |
+
+_Returns:_  A hashable integer representation of the color array.
+
+***
+
+#### `hashable_to_color(hashable: int) -> np.array`
+
+_This is a static function._
+
+
+| Parameter | Description |
+| --- | --- |
+| hashable | A hashable integer representing an RGB color. |
+
+_Returns:_  A color as a numpy array of integers between 0 and 255: [r, g, b]
+
+***
+
 ## `AudioUtils`
 
 `from tdw.tdw_utils import AudioUtils`

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 from pathlib import Path
 
-__version__ = "1.7.3.0"
+__version__ = "1.7.3.1"
 readme_path = Path('../README.md')
 if readme_path.exists():
     long_description = readme_path.read_text(encoding='utf-8')

--- a/Python/tdw/tdw_utils.py
+++ b/Python/tdw/tdw_utils.py
@@ -590,6 +590,26 @@ class TDWUtils:
         forces = np.array(forces, dtype=np.float32)
         return base64.b64encode(forces).decode()
 
+    @staticmethod
+    def color_to_hashable(color: Union[np.array, Tuple[int, int, int]]) -> int:
+        """
+        :param color: The color as an RGB array or tuple, where each value is between 0 and 255.
+
+        :return: A hashable integer representation of the color array.
+        """
+
+        return (color[0] << 16) + (color[1] << 8) + color[2]
+
+    @staticmethod
+    def hashable_to_color(hashable: int) -> np.array:
+        """
+        :param hashable: A hashable integer representing an RGB color.
+
+        :return: A color as a numpy array of integers between 0 and 255: [r, g, b]
+        """
+
+        return np.array([(hashable >> 16) & 255, (hashable >> 8) & 255, hashable & 255], dtype=int)
+
 
 class AudioUtils:
     """

--- a/Python/tdw/tdw_utils.py
+++ b/Python/tdw/tdw_utils.py
@@ -605,7 +605,7 @@ class TDWUtils:
         """
         :param hashable: A hashable integer representing an RGB color.
 
-        :return: A color as a numpy array of integers between 0 and 255: [r, g, b]
+        :return: A color as a numpy array of integers between 0 and 255: `[r, g, b]`
         """
 
         return np.array([(hashable >> 16) & 255, (hashable >> 8) & 255, hashable & 255], dtype=int)


### PR DESCRIPTION
### `tdw` module

#### `TDWUtils`

- Added: `color_to_hashable()`. Convert a color to a hashable integer.
- Added: `hashable_to_color()`. Convert a hashable integer to a color.