### PR TITLE
Fixed: Bounds data is inaccurate

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -10,6 +10,7 @@ To upgrade from TDW v1.6 to v1.7, read [this guide](Documentation/v1.6_to_v1.7).
 
 - When the build fails to deserialize a list of commands, the error message is more informative.
 - Fixed: Various graphics glitches when enabling/disabling cameras.
+- Fixed: `Bounds` output data is incorrect.
 
 ### Documentation
 

--- a/Python/tdw/tdw_utils.py
+++ b/Python/tdw/tdw_utils.py
@@ -642,7 +642,8 @@ class TDWUtils:
                 "left": np.array(bounds.get_left(index)),
                 "right": np.array(bounds.get_right(index)),
                 "front": np.array(bounds.get_front(index)),
-                "back": np.array(bounds.get_back(index))}
+                "back": np.array(bounds.get_back(index)),
+                "center": np.array(bounds.get_center(index))}
 
     @staticmethod
     def get_closest_position_in_bounds(origin: np.array, bounds: Bounds, index: int) -> np.array:


### PR DESCRIPTION
Fixed: `Bounds` output data is incorrect.