### PR TITLE
Replaced Python keyboard module with Unity keyboard listeners

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -22,6 +22,14 @@ To upgrade from TDW v1.6 to v1.7, read [this guide](Documentation/v1.6_to_v1.7).
 | ----------- | -------------------- |
 | `Keyboard`  | Keyboard input data. |
 
+### `tdw` module
+
+- Removed `keyboard` as a required module.
+
+#### `KeyboardController`
+
+- Controller now uses `Keyboard` output data from the simulator to detect keyboard input instead of the Python `keyboard` module, which is less reliable and doesn't work on OS X.
+
 ## v1.7.8
 
 ### Python

--- a/Documentation/python/keyboard_controller.md
+++ b/Documentation/python/keyboard_controller.md
@@ -6,6 +6,11 @@
 
 Listen for keyboard input to send commands.
 
+Keyboard input is registered _from the build, not the controller._ For this controller to work, you must:
+
+- Run the build on the same machine as the keyboard.
+- Have the build window as the focused window (i.e. not minimized).
+
 Usage:
 
 ```python
@@ -14,22 +19,21 @@ from tdw.tdw_utils import TDWUtils
 
 def stop():
     done = True
+    c.communicate({"$type": "terminate"})
 
 done = False
 c = KeyboardController()
 c.start()
 
 # Quit.
-c.listen(key="esc", commands=None, function=stop)
+c.listen(key="esc", function=stop)
 
 # Equivalent to c.start()
-c.listen(key="r", commands={"$type": "load_scene", "scene_name": "ProcGenScene"}, function=None)
+c.listen(key="r", commands={"$type": "load_scene", "scene_name": "ProcGenScene"})
 
 while not done:
     # Receive data. Load the scene when r is pressed. Quit when Esc is pressed.
     c.communicate([])
-# Stop the build.
-c.communicate({"$type": "terminate"})
 ```
 
 ***
@@ -52,7 +56,7 @@ Create the network socket and bind the socket to the port.
 
 ***
 
-#### `communicate(self, commands: Union[dict, List[dict]]) -> list`
+#### `communicate(self, commands: Union[dict, List[dict]]) -> List[bytes]`
 
 Listen for when a key is pressed and send commands.
 
@@ -60,11 +64,12 @@ Listen for when a key is pressed and send commands.
 | --- | --- |
 | key | The keyboard key. |
 | commands | Commands to be sent when the key is pressed. |
-| function | A function to be invoked when the key is pressed. |
+| function | Function to invoke when the key is pressed. |
+| events | Listen to these keyboard events for this `key`. Options: `"press"`, `"hold"`, `"release"`. If None, this defaults to `["press"]`. |
 
 ***
 
-#### `listen(self, key: str, commands: Union[dict, List[dict]] = None, function=None) -> None`
+#### `listen(self, key: str, commands: Union[dict, List[dict]] = None, function=None, events: List[str] = None) -> None`
 
 Listen for when a key is pressed and send commands.
 
@@ -72,7 +77,8 @@ Listen for when a key is pressed and send commands.
 | --- | --- |
 | key | The keyboard key. |
 | commands | Commands to be sent when the key is pressed. |
-| function | A function to be invoked when the key is pressed. |
+| function | Function to invoke when the key is pressed. |
+| events | Listen to these keyboard events for this `key`. Options: `"press"`, `"hold"`, `"release"`. If None, this defaults to `["press"]`. |
 
 ***
 

--- a/Python/example_controllers/keyboard_controls.py
+++ b/Python/example_controllers/keyboard_controls.py
@@ -11,75 +11,78 @@ class KeyboardControls(KeyboardController):
     def __init__(self, port: int = 1071):
         super().__init__(port=port)
         self.done = False
+        self.avatar_id = "a"
 
-    def run(self, force=80, torque=100):
+    def move(self, direction: int, force: float = 80) -> dict:
         """
-        :param force: The force magnitude used to move the avatar.
-        :param torque: The torque magnitude to turn the avatar by.
+        :param direction: The direction of movement.
+        :param force: The force of the movement.
+
+        :return: A `move_avatar_forward_by` command.
         """
 
+        return {"$type": "move_avatar_forward_by",
+                "magnitude": force * direction,
+                "avatar_id": self.avatar_id}
+
+    def turn(self, direction: int, torque: float = 100):
+        """
+        :param direction: The direction of the turn.
+        :param torque: The torque force of the turn.
+
+        :return: A `turn_avatar_by` command.
+        """
+
+        return {"$type": "turn_avatar_by",
+                "torque": torque * direction,
+                "avatar_id": self.avatar_id}
+
+    def stop(self) -> None:
+        """
+        End the simulation.
+        """
+
+        self.communicate({"$type": "terminate"})
+        self.done = True
+
+    def run(self):
         print("W, up-arrow = Move forward")
         print("S, down-arrow = Move backward")
         print("A, left-arrow = Turn counterclockwise")
         print("D, right-arrow = Turn clockwise")
         print("Esc = Quit")
 
-        # Listen for keyboard input for movement.
-        self.listen("w", commands={"$type": "move_avatar_forward_by",
-                                   "magnitude": force,
-                                   "avatar_id": "a"})
-        self.listen("up", commands={"$type": "move_avatar_forward_by",
-                                    "magnitude": force,
-                                    "avatar_id": "a"})
-        self.listen("s", commands={"$type": "move_avatar_forward_by",
-                                   "magnitude": -force,
-                                   "avatar_id": "a"})
-        self.listen("down", commands={"$type": "move_avatar_forward_by",
-                                      "magnitude": -force,
-                                      "avatar_id": "a"})
-        self.listen("d", commands={"$type": "turn_avatar_by",
-                                   "torque": torque,
-                                   "avatar_id": "a"})
-        self.listen("right", commands={"$type": "turn_avatar_by",
-                                       "torque": torque,
-                                       "avatar_id": "a"})
-        self.listen("a", commands={"$type": "turn_avatar_by",
-                                   "torque": -torque,
-                                   "avatar_id": "a"})
-        self.listen("left", commands={"$type": "turn_avatar_by",
-                                      "torque": -torque,
-                                      "avatar_id": "a"})
-        # Listen for keyboard input to quit.
-        self.listen("esc", function=self.stop)
-
         self.start()
         # Create the room.
         commands = [TDWUtils.create_empty_room(12, 12)]
         # Create the avatar.
-        commands.extend(TDWUtils.create_avatar(avatar_type="A_Img_Caps", avatar_id="a"))
+        commands.extend(TDWUtils.create_avatar(avatar_type="A_Img_Caps", avatar_id=self.avatar_id))
         # 1. Set high drag values so it doesn't feel like the avatar is sliding on ice.
         # 2. Set the room's floor material.
+        # 3. Request keyboard input.
         commands.extend([{"$type": "set_avatar_drag",
                           "drag": 10,
                           "angular_drag": 20,
-                          "avatar_id": "a"},
+                          "avatar_id": self.avatar_id},
                          self.get_add_material("parquet_alternating_orange", library="materials_high.json"),
                          {"$type": "set_proc_gen_floor_material",
                           "name": "parquet_alternating_orange"},
                          {"$type": "set_proc_gen_floor_texture_scale",
                           "scale": {"x": 8, "y": 8}}])
         self.communicate(commands)
+
+        self.listen(key="W", commands=self.move(direction=1), events=["press", "hold"])
+        self.listen(key="UpArrow", commands=self.move(direction=1), events=["press", "hold"])
+        self.listen(key="S", commands=self.move(direction=-1), events=["press", "hold"])
+        self.listen(key="DownArrow", commands=self.move(direction=1), events=["press", "hold"])
+        self.listen(key="A", commands=self.turn(direction=-1), events=["press", "hold"])
+        self.listen(key="LeftArrow", commands=self.turn(direction=-1), events=["press", "hold"])
+        self.listen(key="S", commands=self.turn(direction=1), events=["press", "hold"])
+        self.listen(key="RightArrow", commands=self.turn(direction=1), events=["press", "hold"])
+        self.listen(key="Escape", function=self.stop, events=["press"])
+
         while not self.done:
-            # Listen for keyboard input to add other commands.
             self.communicate([])
-        self.communicate({"$type": "terminate"})
-
-    def stop(self):
-        """
-        Stop the controller and the build.
-        """
-
-        self.done = True
 
 
 if __name__ == "__main__":

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 from pathlib import Path
 
-__version__ = "1.7.9.1"
+__version__ = "1.7.9.2"
 readme_path = Path('../README.md')
 if readme_path.exists():
     long_description = readme_path.read_text(encoding='utf-8')
@@ -31,5 +31,5 @@ setup(
     include_package_data=True,
     keywords='unity simulation ml machine-learning',
     install_requires=['pyzmq', 'numpy', 'scipy', 'pillow', 'tqdm', 'psutil', 'boto3', 'botocore', 'requests',
-                      'pyinstaller', 'keyboard'],
+                      'pyinstaller'],
 )

--- a/Python/tdw/keyboard_controller.py
+++ b/Python/tdw/keyboard_controller.py
@@ -1,11 +1,16 @@
-from typing import List, Union
-import keyboard
+from typing import List, Union, Dict
 from tdw.controller import Controller
+from tdw.output_data import OutputData, Keyboard
 
 
 class KeyboardController(Controller):
     """
     Listen for keyboard input to send commands.
+
+    Keyboard input is registered _from the build, not the controller._ For this controller to work, you must:
+
+    - Run the build on the same machine as the keyboard.
+    - Have the build window as the focused window (i.e. not minimized).
 
     Usage:
 
@@ -15,22 +20,21 @@ class KeyboardController(Controller):
 
     def stop():
         done = True
+        c.communicate({"$type": "terminate"})
 
     done = False
     c = KeyboardController()
     c.start()
 
     # Quit.
-    c.listen(key="esc", commands=None, function=stop)
+    c.listen(key="esc", function=stop)
 
     # Equivalent to c.start()
-    c.listen(key="r", commands={"$type": "load_scene", "scene_name": "ProcGenScene"}, function=None)
+    c.listen(key="r", commands={"$type": "load_scene", "scene_name": "ProcGenScene"})
 
     while not done:
         # Receive data. Load the scene when r is pressed. Quit when Esc is pressed.
         c.communicate([])
-    # Stop the build.
-    c.communicate({"$type": "terminate"})
     ```
     """
 
@@ -46,30 +50,86 @@ class KeyboardController(Controller):
         # Commands that should be added due to key presses on this frame.
         self.on_key_commands: List[dict] = []
 
-        super().__init__(port=port, check_version=check_version, launch_build=launch_build)
+        # Dictionaries of actions. Key = a keyboard key as a string.
+        self._press = dict()
+        self._hold = dict()
+        self._release = dict()
 
-    def communicate(self, commands: Union[dict, List[dict]]) -> list:
+        super().__init__(port=port, check_version=check_version, launch_build=launch_build)
+        self.communicate({"$type": "send_keyboard",
+                          "frequency": "always"})
+
+    def _do_event(self, k: str, events: dict) -> None:
+        """
+        Invoke an event if the key is in the events dictionary.
+
+        :param k: The keyboard key as a string.
+        :param events: The events dictionary.
+        """
+
+        if k in events:
+            # Append commands to the next `communicate()` call.
+            if isinstance(events[k], list):
+                self.on_key_commands.extend(events[k])
+            # Invoke a function.
+            else:
+                events[k]()
+
+    def communicate(self, commands: Union[dict, List[dict]]) -> List[bytes]:
         if isinstance(commands, dict):
             commands = [commands]
         # Add commands from key presses.
         commands.extend(self.on_key_commands[:])
         # Clear the on-key commands.
         self.on_key_commands.clear()
-        return super().communicate(commands)
+        # Send the commands.
+        resp = super().communicate(commands)
 
-    def listen(self, key: str, commands: Union[dict, List[dict]] = None, function=None) -> None:
+        # Get keyboard input.
+        for i in range(len(resp) - 1):
+            r_id = OutputData.get_data_type_id(resp[i])
+            if r_id == "keyb":
+                keys = Keyboard(resp[i])
+                # Listen for events where the key was first pressed on the previous frame.
+                for j in range(keys.get_num_pressed()):
+                    self._do_event(k=keys.get_pressed(j), events=self._press)
+                # Listen for keys currently held down.
+                for j in range(keys.get_num_held()):
+                    self._do_event(k=keys.get_held(j), events=self._hold)
+                # Listen for keys that were released.
+                for j in range(keys.get_num_released()):
+                    self._do_event(k=keys.get_released(j), events=self._release)
+        return resp
+
+    def listen(self, key: str, commands: Union[dict, List[dict]] = None, function=None, events: List[str] = None) -> None:
         """
         Listen for when a key is pressed and send commands.
 
         :param key: The keyboard key.
         :param commands: Commands to be sent when the key is pressed.
-        :param function: A function to be invoked when the key is pressed.
+        :param function: Function to invoke when the key is pressed.
+        :param events: Listen to these keyboard events for this `key`. Options: `"press"`, `"hold"`, `"release"`. If None, this defaults to `["press"]`.
         """
 
+        response = None
         if commands is not None:
-            keyboard.on_press_key(key, lambda e: self._set_frame_commands(commands))
-        if function is not None:
-            keyboard.on_press_key(key, lambda e: function())
+            if isinstance(commands, dict):
+                commands = [commands]
+            response = commands
+        elif function is not None:
+            response = function
+        if response is None:
+            return
+        if events is None:
+            events = ["press"]
+
+        # Subscribe to events.
+        if "press" in events:
+            self._press[key] = response
+        if "hold" in events:
+            self._hold[key] = response
+        if "release" in events:
+            self._release[key] = response
 
     def _set_frame_commands(self, commands: Union[dict, List[dict]]) -> None:
         """
@@ -81,4 +141,3 @@ class KeyboardController(Controller):
         if isinstance(commands, dict):
             commands = [commands]
         self.on_key_commands = commands
-

--- a/Python/tdw/keyboard_controller.py
+++ b/Python/tdw/keyboard_controller.py
@@ -1,4 +1,4 @@
-from typing import List, Union, Dict
+from typing import List, Union
 from tdw.controller import Controller
 from tdw.output_data import OutputData, Keyboard
 


### PR DESCRIPTION
### `tdw` module

- Removed `keyboard` as a required module.

#### `KeyboardController`

- Controller now uses `Keyboard` output data from the simulator to detect keyboard input instead of the Python `keyboard` module, which is less reliable and doesn't work on OS X.