### PR TITLE
Added: set_ambient_color

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -8,6 +8,12 @@ To upgrade from TDW v1.6 to v1.7, read [this guide](Documentation/v1.6_to_v1.7).
 
 ### Command API
 
+#### New Commands
+
+| Command             | Description                                     |
+| ------------------- | ----------------------------------------------- |
+| `set_ambient_color` | Set the ambient color of the scene environment. |
+
 #### Modified Commands
 
 | Command          | Description                                                  |

--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -10,9 +10,9 @@ To upgrade from TDW v1.6 to v1.7, read [this guide](Documentation/v1.6_to_v1.7).
 
 #### New Commands
 
-| Command             | Description                                     |
-| ------------------- | ----------------------------------------------- |
-| `set_ambient_color` | Set the ambient color of the scene environment. |
+| Command       | Description                   |
+| ------------- | ----------------------------- |
+| `tint_skybox` | Tint the color of the skybox. |
 
 #### Modified Commands
 

--- a/Documentation/api/command_api.md
+++ b/Documentation/api/command_api.md
@@ -18,6 +18,7 @@
 | [`pause_editor`](#pause_editor) | Pause Unity Editor.  |
 | [`rotate_hdri_skybox_by`](#rotate_hdri_skybox_by) | Rotate the HDRI skybox by a given value and the sun light by the same value in the opposite direction, to maintain alignment. |
 | [`send_nav_mesh_path`](#send_nav_mesh_path) | Tell the build to send data of a path on the NavMesh from the origin to the destination.  |
+| [`set_ambient_color`](#set_ambient_color) | Set the ambient color of the scene environment. |
 | [`set_download_timeout`](#set_download_timeout) | Set the timeout after which an Asset Bundle Command (e.g. add_object) will retry a download. The default timeout is 30 minutes, which should always be sufficient. Send this command only if your computer or Internet connection is very slow. |
 | [`set_floorplan_roof`](#set_floorplan_roof) | Show or hide the roof of a floorplan scene. This command only works if the current scene is a floorplan added via the add_scene command: "floorplan_1a", "floorplan_4b", etc.  |
 | [`set_gravity_vector`](#set_gravity_vector) | Set the gravity vector in the scene. |
@@ -670,6 +671,21 @@ Tell the build to send data of a path on the NavMesh from the origin to the dest
 | `"origin"` | Vector3 | The origin of the path. | |
 | `"destination"` | Vector3 | The destination of the path. | |
 | `"id"` | int | The ID of the path. The output data will contain a matching ID. | 0 |
+
+***
+
+## **`set_ambient_color`**
+
+Set the ambient color of the scene environment.
+
+
+```python
+{"$type": "set_ambient_color", "color": {"r": 0.219607845, "g": 0.0156862754, "b": 0.6901961, "a": 1.0}}
+```
+
+| Parameter | Type | Description | Default |
+| --- | --- | --- | --- |
+| `"color"` | Color | The ambient color. | |
 
 ***
 

--- a/Documentation/api/command_api.md
+++ b/Documentation/api/command_api.md
@@ -18,7 +18,6 @@
 | [`pause_editor`](#pause_editor) | Pause Unity Editor.  |
 | [`rotate_hdri_skybox_by`](#rotate_hdri_skybox_by) | Rotate the HDRI skybox by a given value and the sun light by the same value in the opposite direction, to maintain alignment. |
 | [`send_nav_mesh_path`](#send_nav_mesh_path) | Tell the build to send data of a path on the NavMesh from the origin to the destination.  |
-| [`set_ambient_color`](#set_ambient_color) | Set the ambient color of the scene environment. |
 | [`set_download_timeout`](#set_download_timeout) | Set the timeout after which an Asset Bundle Command (e.g. add_object) will retry a download. The default timeout is 30 minutes, which should always be sufficient. Send this command only if your computer or Internet connection is very slow. |
 | [`set_floorplan_roof`](#set_floorplan_roof) | Show or hide the roof of a floorplan scene. This command only works if the current scene is a floorplan added via the add_scene command: "floorplan_1a", "floorplan_4b", etc.  |
 | [`set_gravity_vector`](#set_gravity_vector) | Set the gravity vector in the scene. |
@@ -31,6 +30,7 @@
 | [`set_time_step`](#set_time_step) | Set Time.fixedDeltaTime (Unity's physics step, as opposed to render time step). NOTE: Doubling the time_step is NOT equivalent to advancing two physics steps. For more information, see: <ulink url="https://docs.unity3d.com/Manual/TimeFrameManagement.html">https://docs.unity3d.com/Manual/TimeFrameManagement.html</ulink> |
 | [`step_physics`](#step_physics) | Step through the physics without triggering new avatar output, or new commands. |
 | [`terminate`](#terminate) | Terminate the build. |
+| [`tint_skybox`](#tint_skybox) | Tint the color of the skybox. |
 | [`unload_asset_bundles`](#unload_asset_bundles) | Unloads all AssetBundles. Send this command only after destroying all objects in the scene. This command should be used only to free up memory. After sending it, you will need to re-download any objects you want to add to a scene.  |
 
 **Asset Bundle Command**
@@ -674,21 +674,6 @@ Tell the build to send data of a path on the NavMesh from the origin to the dest
 
 ***
 
-## **`set_ambient_color`**
-
-Set the ambient color of the scene environment.
-
-
-```python
-{"$type": "set_ambient_color", "color": {"r": 0.219607845, "g": 0.0156862754, "b": 0.6901961, "a": 1.0}}
-```
-
-| Parameter | Type | Description | Default |
-| --- | --- | --- | --- |
-| `"color"` | Color | The ambient color. | |
-
-***
-
 ## **`set_download_timeout`**
 
 Set the timeout after which an Asset Bundle Command (e.g. add_object) will retry a download. The default timeout is 30 minutes, which should always be sufficient. Send this command only if your computer or Internet connection is very slow.
@@ -906,6 +891,21 @@ Terminate the build.
 ```python
 {"$type": "terminate"}
 ```
+
+***
+
+## **`tint_skybox`**
+
+Tint the color of the skybox.
+
+
+```python
+{"$type": "tint_skybox", "color": {"r": 0.219607845, "g": 0.0156862754, "b": 0.6901961, "a": 1.0}}
+```
+
+| Parameter | Type | Description | Default |
+| --- | --- | --- | --- |
+| `"color"` | Color | The ambient color. | |
 
 ***
 


### PR DESCRIPTION
# How to test

1. Download Unity 2019.4.16
2. In TDWBase: `git fetch` and `git checkout set_ambient_color`
3. Run this controller:

```python
from tdw.controller import Controller
from tdw.tdw_utils import TDWUtils

c = Controller(launch_build=False)
c.start()
commands = [{"$type": "create_empty_environment"}]
commands.extend(TDWUtils.create_avatar(position={"x": -1, "y": 1, "z": -1}, look_at={"x": 0, "y": 0, "z": 0}))
q = 5 / 255.0
commands.append({"$type": "tint_skybox",
                 "color": {"r": q, "g": q, "b": q, "a": q}})
commands.append({"$type": "set_vignette",
                 "enabled": False})
commands.append(c.get_add_object("rh10", object_id=0))
c.communicate(commands)
```

4. Run the build in Unity Editor

# Changes

### Command API

#### New Commands

| Command             | Description                                     |
| ------------------- | ----------------------------------------------- |
| `tint_skybox` | Tint the color of the skybox. |