### PR TITLE
Added: QuaternionUtils.get_y_angle()

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -14,6 +14,12 @@ To upgrade from TDW v1.6 to v1.7, read [this guide](Documentation/v1.6_to_v1.7).
 | ---------------- | ------------------------------------------------------------ |
 | `set_pass_masks` | Added `_albedo` pass. This only color and texture,  as if lit with only ambient light. |
 
+### `tdw` module
+
+#### `QuaternionUtils`
+
+- Added: `get_y_angle()` The angle between two quaternions in degrees around the y axis.
+
 ## v1.7.9
 
 ### Command API

--- a/Documentation/python/tdw_utils.md
+++ b/Documentation/python/tdw_utils.md
@@ -691,3 +691,18 @@ _Returns:_  The Euler angles representation of the quaternion.
 
 ***
 
+#### `get_y_angle(q1: np.array, q2: np.array) -> float`
+
+_This is a static function._
+
+Source: https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles
+
+| Parameter | Description |
+| --- | --- |
+| q1 | The first quaternion. |
+| q2 | The second quaternion. |
+
+_Returns:_  The angle between the two quaternions in degrees around the y axis.
+
+***
+

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 from pathlib import Path
 
-__version__ = "1.7.10.0"
+__version__ = "1.7.10.1"
 readme_path = Path('../README.md')
 if readme_path.exists():
     long_description = readme_path.read_text(encoding='utf-8')

--- a/Python/tdw/tdw_utils.py
+++ b/Python/tdw/tdw_utils.py
@@ -962,3 +962,18 @@ class QuaternionUtils:
         ez = np.degrees(np.arctan2(t3, t4))
 
         return np.array([ex, ey, ez])
+
+    @staticmethod
+    def get_y_angle(q1: np.array, q2: np.array) -> float:
+        """
+        Source: https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles
+
+        :param q1: The first quaternion.
+        :param q2: The second quaternion.
+
+        :return: The angle between the two quaternions in degrees around the y axis.
+        """
+
+        qd = QuaternionUtils.multiply(QuaternionUtils.get_conjugate(q1), q2)
+
+        return np.rad2deg(2 * np.arcsin(qd[1]))


### PR DESCRIPTION
### `tdw` module

#### `QuaternionUtils`

- Added: `get_y_angle()` The angle between two quaternions in degrees around the y axis.