### PR TITLE
Socket hanging

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -36,8 +36,12 @@ To upgrade from TDW v1.7 to v1.8, read [this guide](Documentation/upgrade_guides
 
 ### Build
 
+- Upgraded to Unity 2020.2.7
 - Fixed: If `set_kinematic_state` is sent more than once in a row to the same object with `kinematic=True`, the collision detection mode will be set incorrectly.
 - Fixed: Audio glitches when using Resonance Audio because the playback is doubled.
+- Fixed: Rare socket hanging if the build can't send a message.
+- Fixed: ZMQ error if the build is launched a few seconds before the controller is launched.
+- Fixed: Can't draw Flex particles in Linux (see note in upgrade guide).
 
 ### Documentation
 

--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -37,6 +37,7 @@ To upgrade from TDW v1.7 to v1.8, read [this guide](Documentation/upgrade_guides
 ### Build
 
 - Upgraded to Unity 2020.2.7
+- Fixed: `rotate_sensor_container_by` rotations around a local axis instead of a world axis
 - Fixed: If `set_kinematic_state` is sent more than once in a row to the same object with `kinematic=True`, the collision detection mode will be set incorrectly.
 - Fixed: Audio glitches when using Resonance Audio because the playback is doubled.
 - Fixed: Rare socket hanging if the build can't send a message.

--- a/Documentation/upgrade_guides/v1.7_to_v1.8.md
+++ b/Documentation/upgrade_guides/v1.7_to_v1.8.md
@@ -8,13 +8,17 @@
 
 #### Bug: Can't create a Linux build without deleting some Flex shader files
 
-_(This is relevant only to users who have access to the C# source code in the private TDWBase repo.)_
+~~_(This is relevant only to users who have access to the C# source code in the private TDWBase repo.)_~~
 
-To create a Linux build, delete all Flex shaders located in `TDWBase/Assets/NVIDIA/Flex/Resources/Shaders` that have `DrawParticles` or `Fluid` in their name. Otherwise, the Editor will crash to desktop. This is handled automatically when we build and upload TDW releases to GitHub.
+~~To create a Linux build, delete all Flex shaders located in `TDWBase/Assets/NVIDIA/Flex/Resources/Shaders` that have `DrawParticles` or `Fluid` in their name. Otherwise, the Editor will crash to desktop. This is handled automatically when we build and upload TDW releases to GitHub.~~
+
+**Update**: Fixed as of March 7, 2021, having upgraded to Unity 2020.2.7
 
 #### Bug: Can't draw Flex particles on Linux
 
 It's currently not possible to draw Flex particles (`"draw_particles"` in the Command API) in Linux. Attempting to create a build with the Flex particle shaders for Linux results in a crash-to-desktop. This is new as of Unity 2020.2.2 and it is likely that a future Unity Engine upgrade (i.e. to Unity 2020.2.x) will fix it. As a matter of course, we apply minor Unity Engine updates to TDW whenever they're available. Should one of these updates fix this particular issue, we'll note it in the changelog.
+
+**Update**: This has probably been fixed (see update note from March 7 in the above section). However, we don't have Ubuntu 16 test machines and haven't been able to test Flex on Linux.
 
 ## Renamed some streamed scenes
 


### PR DESCRIPTION
### Build

- Upgraded to Unity 2020.2.7
- Fixed: `rotate_sensor_container_by` rotations around a local axis instead of a world axis
- Fixed: ZMQ error if the build is launched a few seconds before the controller is launched.
- Fixed: Can't draw Flex particles in Linux (see note in upgrade guide).