### PR TITLE
Added optional log parameter to send_version

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -6,6 +6,14 @@ To upgrade from TDW v1.7 to v1.8, read [this guide](Documentation/upgrade_guides
 
 ## v1.8.5
 
+### Command API
+
+#### Modified Commands
+
+| Command        | Description                                                  |
+| -------------- | ------------------------------------------------------------ |
+| `send_version` | Added optional parameter `log` to log the TDW version in the Player or Editor log (default value is True). |
+
 ### Model Library
 
 - Marked refridgerator_slim as do_not_use (colliders are rotated)

--- a/Documentation/api/command_api.md
+++ b/Documentation/api/command_api.md
@@ -6200,11 +6200,12 @@ Receive data about the build version.
 ```
 
 ```python
-{"$type": "send_version", "frequency": "once"}
+{"$type": "send_version", "log": True, "frequency": "once"}
 ```
 
 | Parameter | Type | Description | Default |
 | --- | --- | --- | --- |
+| `"log"` | bool | If True, log the TDW version in the Player or Editor log. | True |
 | `"frequency"` | Frequency | The frequency at which data is sent. | "once" |
 
 #### Frequency


### PR DESCRIPTION
### Command API

#### Modified Commands

| Command        | Description                                                  |
| -------------- | ------------------------------------------------------------ |
| `send_version` | Added optional parameter `log` to log the TDW version in the Player or Editor log (default value is True). |