### PR TITLE
Added code to PyImpact to optionally prevent a droning audio effect

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -36,6 +36,15 @@ To upgrade from TDW v1.7 to v1.8, read [this guide](Documentation/upgrade_guides
 #### `PyImpact`
 
 - Added and update many object audio values in objects.csv
+- Fixed: PyImpact sometimes creates a droning audio effect. To prevent this, PyImpact will ignore collision events if the same pair of objects registers an `enter` and `stay` collision event on the same frame.
+
+### Documentation
+
+#### Modified Documentation
+
+| Document           | Description                                                  |
+| ------------------ | ------------------------------------------------------------ |
+| `impact_sounds.md` | Added a section and code example for how to prevent audio droning. |
 
 ## v1.8.4
 

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 from pathlib import Path
 
-__version__ = "1.8.5.0"
+__version__ = "1.8.5.1"
 readme_path = Path('../README.md')
 if readme_path.exists():
     long_description = readme_path.read_text(encoding='utf-8')

--- a/Python/tdw/py_impact.py
+++ b/Python/tdw/py_impact.py
@@ -386,9 +386,8 @@ class PyImpact:
                 continue
             collider_id = collision.get_collider_id()
             collidee_id = collision.get_collidee_id()
-            ids = (collider_id, collidee_id)
             # Ignore collisions if there is a "stay" event, because this can create a droning effect.
-            if ids in stays:
+            if (collider_id, collidee_id) in stays:
                 continue
             # Skip objects that for some reason aren't in the cached data.
             if collider_id not in self.object_names or collidee_id not in self.object_names:

--- a/Python/tdw/py_impact.py
+++ b/Python/tdw/py_impact.py
@@ -377,6 +377,8 @@ class PyImpact:
         for i in range(rigidbodies.get_num()):
             object_id = rigidbodies.get_id(i)
             speeds[object_id] = np.linalg.norm(rigidbodies.get_velocity(i))
+        # Get all stays.
+        stays = [(c.get_collider_id(), c.get_collidee_id()) for c in collisions if c.get_state() == "stay"]
         # Play sounds from collisions.
         for collision in collisions:
             # Ignore invalid collisions.
@@ -384,6 +386,10 @@ class PyImpact:
                 continue
             collider_id = collision.get_collider_id()
             collidee_id = collision.get_collidee_id()
+            ids = (collider_id, collidee_id)
+            # Ignore collisions if there is a "stay" event, because this can create a droning effect.
+            if ids in stays:
+                continue
             # Skip objects that for some reason aren't in the cached data.
             if collider_id not in self.object_names or collidee_id not in self.object_names:
                 continue


### PR DESCRIPTION
#### `PyImpact`

- Fixed: PyImpact sometimes creates a droning audio effect. To prevent this, PyImpact will ignore collision events if the same pair of objects registers an `enter` and `stay` collision event on the same frame.

### Documentation

#### Modified Documentation

| Document           | Description                                                  |
| ------------------ | ------------------------------------------------------------ |
| `impact_sounds.md` | Added a section and code example for how to prevent audio droning. |