### PR TITLE
Set +x permission for OSX build and assume that it's a .zip file

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -20,6 +20,10 @@ To upgrade from TDW v1.7 to v1.8, read [this guide](Documentation/upgrade_guides
 
 - Fixed: Constructor doesn't pass port number to the build if `launch_build == True`
 
+### Build
+
+- Fixed: Can't double-click TDW.app in OS X because the file is damaged. The OS X version of TDW is now a .zip instead of .tar.gz (like it was prior to v1.8).
+
 ### Docker
 
 - Fixed: `pull.sh` fails with error: `unary operator expected`


### PR DESCRIPTION
Closes #159 

# How to test

### Test 1

1. In the TDW repo, `git fetch` and `git checkout damaged_app`
2. [Download and unzip this build](https://github.com/threedworld-mit/tdw/releases/tag/1.8.9_test)
3. Run this controller:

```python
from tdw.controller import Controller
c = Controller(launch_build=False)
print("OK!")
c.communicate({"$type": "terminate"})
```

4. Run the build *by double-clicking TDW.app*

**Result: The build launches. The controller prints `OK!` and exits.**

### Test 2

1. Run the same controller as in Test 1
2. Run the build in the terminal

**Result: I'm not sure what will happen!** I expect that the build doesn't have +x permissions so it won't work

### Test 3

Run this test only if Test 2 failed (the build didn't launch)

1. `chmod +x TDW.app/Contents/MacOS/TDW`
2. Run the same controller as in Test 1
3. Run the build in the terminal
4. Run the same controller as in Test 1
5. Run the build *by double-clicking TDW.app*

**Result: The build launches both by double-clicking TDW.app and by launching it in the terminal.**

# Changes

### Build

- Fixed: Can't double-click TDW.app in OS X because the file is damaged. The OS X version of TDW is now a .zip instead of .tar.gz (like it was prior to v1.8).