### PR TITLE
Launch setup.sh to fix .app errors

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -20,6 +20,10 @@ To upgrade from TDW v1.7 to v1.8, read [this guide](Documentation/upgrade_guides
 
 - Fixed: Constructor doesn't pass port number to the build if `launch_build == True`
 
+### Build
+
+- **Fixed: Can't launch TDW.app by double-clicking it.** If you download the build from the Releases page on the repo, you can run `setup.sh` (located in the same directory as `TDW.app`). If you download the build by launching a controller, i.e. `c = Controller()`, the controller will automatically fix TDW.app before launching it.
+
 ### Docker
 
 - Fixed: `pull.sh` fails with error: `unary operator expected`

--- a/Documentation/misc_frontend/osx.md
+++ b/Documentation/misc_frontend/osx.md
@@ -20,6 +20,10 @@ As with all OS X programs, the .app can't be directly opened in the shell. Inste
 
 If you aren't using command-line arguments, you can double-click and run the .app like any other.
 
+## "When I double-click TDW.app I get an error: `TDW.app is damaged and can't be opened`"
+
+This is a [known Unity bug](https://issuetracker.unity3d.com/issues/macos-builds-now-contain-a-quarantine-attribute) and it will occur if you download the build from TDW's releases page. To fix it, run `setup.sh` (located in the same directory as `TDW.app`).
+
 ## "I'm receiving `localhost` errors"
 
 The build might fail to do anything because `localhost` isn't a listed host. In Unity Editor, you'll see an error like this:

--- a/Documentation/python/controller.md
+++ b/Documentation/python/controller.md
@@ -207,11 +207,15 @@ _Returns:_ The frame as an integer.
 
 ***
 
-#### `launch_build(port = 1071) -> None`
+#### `launch_build(port: int = 1071) -> None`
 
 _This is a static function._
 
 Launch the build. If a build doesn't exist at the expected location, download one to that location.
+
+| Parameter | Description |
+| --- | --- |
+| port | The socket port. |
 
 ***
 

--- a/Python/tdw/controller.py
+++ b/Python/tdw/controller.py
@@ -328,9 +328,11 @@ class Controller(object):
         return int.from_bytes(frame, byteorder='big')
 
     @staticmethod
-    def launch_build(port = 1071) -> None:
+    def launch_build(port: int = 1071) -> None:
         """
         Launch the build. If a build doesn't exist at the expected location, download one to that location.
+
+        :param port: The socket port.
         """
 
         # Download the build.

--- a/Python/tdw/release/build.py
+++ b/Python/tdw/release/build.py
@@ -1,3 +1,5 @@
+from os import getcwd, chdir
+from subprocess import call
 from requests import get, head
 from typing import Tuple
 from platform import system
@@ -86,6 +88,13 @@ class Build:
             tar = tarfile.open(str(zip_path.resolve()))
             tar.extractall(dst)
             tar.close()
+        # Run this to fixed "Damaged App" errors.
+        # Source: https://www.google.com/search?client=firefox-b-1-d&q=unity+damaged+app
+        if platform == "Darwin":
+            cwd = getcwd()
+            chdir(str(Build.BUILD_ROOT_DIR.joinpath("TDW").resolve()))
+            call(["xattr", "-r", "-d", "com.apple.quarantine", "TDW.app"])
+            chdir(cwd)
         print(f"Extracted the file to: {dst}")
         # Delete the zip file.
         zip_path.unlink()


### PR DESCRIPTION
### Build

- **Fixed: Can't launch TDW.app by double-clicking it.** If you download the build from the Releases page on the repo, you can run `setup.sh` (located in the same directory as `TDW.app`). If you download the build by launching a controller, i.e. `c = Controller()`, the controller will automatically fix TDW.app before launching it.