### PR TITLE
Added: TDWUtils.get_bounds_extents

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -19,6 +19,10 @@ To upgrade from TDW v1.7 to v1.8, read [this guide](Documentation/upgrade_guides
 
 - Added to `models_core.json`: camera_box, iron_box, coffeemug, b04_ramlosa_bottle_2015_vray, moet_chandon_bottle_vray, b04_whiskeybottle, 102_pepsi_can_12_fl_oz_vray, candlestick1, golf, b03_toothbrush, b05_calculator, b05_tag_heuer_max2014, b05_executive_pen
 
+### `tdw` module
+
+- Added: `TDWUtils.get_bounds_extents()` Returns the width, length, height of an object's bounds.
+
 ## v1.8.10
 
 ### Command API

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 from pathlib import Path
 
-__version__ = "1.8.11.1"
+__version__ = "1.8.11.2"
 readme_path = Path('../README.md')
 if readme_path.exists():
     long_description = readme_path.read_text(encoding='utf-8')

--- a/Python/tdw/tdw_utils.py
+++ b/Python/tdw/tdw_utils.py
@@ -731,6 +731,19 @@ class TDWUtils:
                 "center": np.array(bounds.get_center(index))}
 
     @staticmethod
+    def get_bounds_extents(bounds: Bounds, index: int) -> np.array:
+        """
+        :param bounds: Bounds output data.
+        :param index: The index in `bounds` of the target object.
+
+        :return: The width (left to right), length (front to back), and height (top to bottom) of the bounds as a numpy array.
+        """
+
+        return np.array([np.linalg.norm(np.array(bounds.get_left(index)) - np.array(bounds.get_right(index))),
+                         np.linalg.norm(np.array(bounds.get_front(index)) - np.array(bounds.get_back(index))),
+                         np.linalg.norm(np.array(bounds.get_top(index)) - np.array(bounds.get_bottom(index)))])
+
+    @staticmethod
     def get_closest_position_in_bounds(origin: np.array, bounds: Bounds, index: int) -> np.array:
         """
         :param origin: The origin from which the distance is calculated.


### PR DESCRIPTION
### `tdw` module

- Added: `TDWUtils.get_bounds_extents()` Returns the width, length, height of an object's bounds.