### PR TITLE
Set the default value of udp to False

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -6,6 +6,12 @@ To upgrade from TDW v1.7 to v1.8, read [this guide](Documentation/upgrade_guides
 
 ## v1.8.16
 
+### `tdw` module
+
+#### `Controller`
+
+- Set the default value of the `udp` parameter of the constructor to `False` (was `True`). This is a hotfix; there are known bugs with the UDP heartbeat that we're still in the process of fixing.
+
 ### Build
 
 - Fixed: `set_visual_material` doesn't work after sending `set_flex_soft_actor`.

--- a/Python/tdw/controller.py
+++ b/Python/tdw/controller.py
@@ -29,7 +29,7 @@ class Controller(object):
     ```
     """
 
-    def __init__(self, port: int = 1071, check_version: bool = True, launch_build: bool = True, udp: bool = True):
+    def __init__(self, port: int = 1071, check_version: bool = True, launch_build: bool = True, udp: bool = False):
         """
         Create the network socket and bind the socket to the port.
 


### PR DESCRIPTION
et the default value of the `udp` parameter of the `Controller` constructor to `False` (was `True`). This is a hotfix; there are known bugs with the UDP heartbeat that we're still in the process of fixing.