### PR TITLE
Build process port

### DIFF
--- a/Python/setup.py
+++ b/Python/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 from pathlib import Path
 
-__version__ = "1.8.16.0"
+__version__ = "1.8.16.1"
 readme_path = Path('../README.md')
 if readme_path.exists():
     long_description = readme_path.read_text(encoding='utf-8')

--- a/Python/tdw/controller.py
+++ b/Python/tdw/controller.py
@@ -69,14 +69,19 @@ class Controller(object):
             # Get the process ID, if any.
             for q in psutil.process_iter():
                 if q.name() == process_name:
-                    self._local_build_is_running = True
-                    build_pid: int = q.pid
-                    # Get the ID of the controller process.
-                    controller_pid: int = os.getpid()
-                    # Start listening for the build process.
-                    t = Thread(target=self._build_process_heartbeat, args=([build_pid, controller_pid]))
-                    t.daemon = True
-                    t.start()
+                    # Get the instance of TDW on the correct port.
+                    for connection in q.connections():
+                        if connection.raddr.port == port:
+                            print("HERE")
+                            self._local_build_is_running = True
+                            build_pid: int = q.pid
+                            # Get the ID of the controller process.
+                            controller_pid: int = os.getpid()
+                            # Start listening for the build process.
+                            t = Thread(target=self._build_process_heartbeat, args=([build_pid, controller_pid]))
+                            t.daemon = True
+                            t.start()
+                            break
                     break
 
         # Set error handling to default values (the build will try to quit on errors and exceptions).

--- a/Python/tdw/controller.py
+++ b/Python/tdw/controller.py
@@ -67,12 +67,14 @@ class Controller(object):
             else:
                 process_name = "TDW.x86_64"
             # Get the process ID, if any.
+            got_build_process: bool = False
             for q in psutil.process_iter():
+                if got_build_process:
+                    break
                 if q.name() == process_name:
                     # Get the instance of TDW on the correct port.
                     for connection in q.connections():
                         if connection.raddr.port == port:
-                            print("HERE")
                             self._local_build_is_running = True
                             build_pid: int = q.pid
                             # Get the ID of the controller process.
@@ -81,8 +83,8 @@ class Controller(object):
                             t = Thread(target=self._build_process_heartbeat, args=([build_pid, controller_pid]))
                             t.daemon = True
                             t.start()
+                            got_build_process = True
                             break
-                    break
 
         # Set error handling to default values (the build will try to quit on errors and exceptions).
         # Request the version to log it and remember here if the Editor is being used.


### PR DESCRIPTION
Fixed: The build process heartbeat can listen for the wrong build on the wrong port.