### PR TITLE
Replaced URLs with public URLs

### DIFF
--- a/Python/setup.py
+++ b/Python/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 from pathlib import Path
 
-__version__ = "1.8.16.2"
+__version__ = "1.8.16.3"
 readme_path = Path('../README.md')
 if readme_path.exists():
     long_description = readme_path.read_text(encoding='utf-8')


### PR DESCRIPTION
For each model just moved from models_full to models_core, the URLs in _models_full.json_ have been fixed. They pointed to the "old" private asset bundle and now point to the public asset bundles.