### PR TITLE
Fixed a NaN error in QuaternionUtils

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -18,6 +18,10 @@ To upgrade from TDW v1.7 to v1.8, read [this guide](Documentation/upgrade_guides
 
 - Fixed: Resonance Audio doesn't work on OS X.
 
+### Python
+
+- Fixed: RuntimeWarning in `QuaternionUtils.get_y_angle()` due to a NaN value.
+
 ## v1.8.18
 
 ### Build

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 from pathlib import Path
 
-__version__ = "1.8.19.0"
+__version__ = "1.8.19.1"
 readme_path = Path('../README.md')
 if readme_path.exists():
     long_description = readme_path.read_text(encoding='utf-8')

--- a/Python/tdw/tdw_utils.py
+++ b/Python/tdw/tdw_utils.py
@@ -1133,10 +1133,4 @@ class QuaternionUtils:
         """
 
         qd = QuaternionUtils.multiply(QuaternionUtils.get_conjugate(q1), q2)
-
-        # Check if we flipped over the axis (more than 180 degrees).
-        if qd[1] > np.pi:
-            a = -np.arcsin(qd[1] % np.pi)
-        else:
-            a = np.arcsin(qd[1])
-        return np.rad2deg(2 * a)
+        return np.rad2deg(2 * np.arcsin(np.clip(qd[1], -1, 1)))

--- a/Python/tdw/tdw_utils.py
+++ b/Python/tdw/tdw_utils.py
@@ -1134,4 +1134,9 @@ class QuaternionUtils:
 
         qd = QuaternionUtils.multiply(QuaternionUtils.get_conjugate(q1), q2)
 
-        return np.rad2deg(2 * np.arcsin(qd[1]))
+        # Check if we flipped over the axis (more than 180 degrees).
+        if qd[1] > np.pi:
+            a = -np.arcsin(qd[1] % np.pi)
+        else:
+            a = np.arcsin(qd[1])
+        return np.rad2deg(2 * a)


### PR DESCRIPTION
### Python

- Fixed: RuntimeWarning in `QuaternionUtils.get_y_angle()` due to a NaN value.