### PR TITLE
Added get_walls() to Overlap output data

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -26,6 +26,12 @@ To upgrade from TDW v1.7 to v1.8, read [this guide](Documentation/upgrade_guides
 | ---------------- | --------------------------------------------------- |
 | `MagnebotWheels` | A message sent when a Magnebot arrives at a target. |
 
+#### Modified Output Data
+
+| Output Data | Modification                                                 |
+| ----------- | ------------------------------------------------------------ |
+| `Overlap`   | Added: `get_walls()`. Returns True if there is a non-floor environment object in the overlap (such as a wall). |
+
 ### Build
 
 - Fixed: Unhandled ArgumentException when trying to add an object with an existing ID.

--- a/Documentation/api/output_data.md
+++ b/Documentation/api/output_data.md
@@ -553,6 +553,7 @@ The IDs of every object that a shape overlaps.
 | `get_id()` | The identity of this overlap (useful if you've requested multiple Overlap objects). | `int` |
 | `get_object_ids()` | The IDs of every object in the overlap shape. | `np.array` |
 | `get_env()` | If true, the overlap shape includes at least one environment object (such as the floor). | `bool` |
+| `get_walls()` | If true, the overlap shape includes at least one environment object that isn't the floor. | `bool` |
 
 ## QuitSignal
 

--- a/Python/tdw/FBOutput/Overlap.py
+++ b/Python/tdw/FBOutput/Overlap.py
@@ -54,9 +54,17 @@ class Overlap(object):
             return bool(self._tab.Get(tdw.flatbuffers.number_types.BoolFlags, o + self._tab.Pos))
         return False
 
-def OverlapStart(builder): builder.StartObject(3)
+    # Overlap
+    def Walls(self):
+        o = tdw.flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
+        if o != 0:
+            return bool(self._tab.Get(tdw.flatbuffers.number_types.BoolFlags, o + self._tab.Pos))
+        return False
+
+def OverlapStart(builder): builder.StartObject(4)
 def OverlapAddId(builder, id): builder.PrependInt32Slot(0, id, 0)
 def OverlapAddObjectIds(builder, objectIds): builder.PrependUOffsetTRelativeSlot(1, tdw.flatbuffers.number_types.UOffsetTFlags.py_type(objectIds), 0)
 def OverlapStartObjectIdsVector(builder, numElems): return builder.StartVector(4, numElems, 4)
 def OverlapAddEnv(builder, env): builder.PrependBoolSlot(2, env, 0)
+def OverlapAddWalls(builder, walls): builder.PrependBoolSlot(3, walls, 0)
 def OverlapEnd(builder): return builder.EndObject()

--- a/Python/tdw/output_data.py
+++ b/Python/tdw/output_data.py
@@ -801,6 +801,9 @@ class Overlap(OutputData):
     def get_env(self) -> bool:
         return self.data.Env()
 
+    def get_walls(self) -> bool:
+        return self.data.Walls()
+
 
 class NavMeshPath(OutputData):
     _STATES = {PathState.PathState.complete: "complete",


### PR DESCRIPTION
#### Modified Output Data

| Output Data | Modification                                                 |
| ----------- | ------------------------------------------------------------ |
| `Overlap`   | Added: `get_walls()`. Returns True if there is a non-floor environment object in the overlap (such as a wall). |