### PR TITLE
Fixed: object IDs are often non-unique

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -6,6 +6,13 @@ To upgrade from TDW v1.7 to v1.8, read [this guide](Documentation/upgrade_guides
 
 ## v1.8.21
 
+### `tdw` module
+
+#### `Controller`
+
+- Fixed: As of a few updates ago, the controller often sends non-unique object IDs. We are still trying to determine what changed in the build's code, but in the meantime, `Controller.get_unique_id()` will always return a unique ID.
+  - Added `Controller.reset_unique_id()` to prevent overflow errors.
+
 ### Build
 
 - Fixed: Rare bug where the build won't receive the full JSON string for very long lists of commands. In these cases, the build will request that the controller resend the message.

--- a/Documentation/python/controller.md
+++ b/Documentation/python/controller.md
@@ -194,6 +194,15 @@ _Returns:_ The new unique ID.
 
 ***
 
+#### `reset_object_id() -> None`
+
+_This is a static function._
+
+Reset the object ID counter to its default value.
+This is a fallback in case of very strange errors; you shouldn't ever need to call this.
+
+***
+
 #### `get_frame(frame: bytes) -> int`
 
 _This is a static function._

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 from pathlib import Path
 
-__version__ = "1.8.21.0"
+__version__ = "1.8.21.1"
 readme_path = Path('../README.md')
 if readme_path.exists():
     long_description = readme_path.read_text(encoding='utf-8')

--- a/Python/tdw/controller.py
+++ b/Python/tdw/controller.py
@@ -29,6 +29,11 @@ class Controller(object):
     ```
     """
 
+    # The ID of the first object.
+    _FIRST_OBJECT_ID: int = 10000
+    # The next object ID.
+    _NEXT_OBJECT_ID: int = _FIRST_OBJECT_ID
+
     def __init__(self, port: int = 1071, check_version: bool = True, launch_build: bool = True, check_build_process: bool = False):
         """
         Create the network socket and bind the socket to the port.
@@ -394,7 +399,18 @@ class Controller(object):
         :return The new unique ID.
         """
 
-        return int.from_bytes(os.urandom(3), byteorder='big')
+        object_id = Controller._NEXT_OBJECT_ID
+        Controller._NEXT_OBJECT_ID += 1
+        return object_id
+
+    @staticmethod
+    def reset_object_id() -> None:
+        """
+        Reset the object ID counter to its default value.
+        This is a fallback in case of very strange errors; you shouldn't ever need to call this.
+        """
+
+        Controller._NEXT_OBJECT_ID = Controller._FIRST_OBJECT_ID
 
     @staticmethod
     def get_frame(frame: bytes) -> int:


### PR DESCRIPTION
### `tdw` module

#### `Controller`

- Fixed: As of a few updates ago, the controller often sends non-unique object IDs. We are still trying to determine what changed in the build's code, but in the meantime, `Controller.get_unique_id()` will always return a unique ID.
  - Added `Controller.reset_unique_id()` to prevent overflow errors.