### PR TITLE
Added: PyPi.required_tdw_version_is_installed()

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -25,6 +25,16 @@ To upgrade from TDW v1.7 to v1.8, read [this guide](Documentation/upgrade_guides
 | ----------- | --------------------------------- |
 | `Lights`    | Data for all lights in the scene. |
 
+### `tdw` module
+
+#### `Build` (backend)
+
+- Added optional parameter `check_head` to `get_url()`. If True, check the HTTP headers to make sure that the release exists.
+
+#### `PyPi` (backend)
+
+- Added: `required_tdw_version_is_installed(required_version, build_version)` Check whether the correct version of TDW is installed. This is useful for other modules such as the Magnebot API that rely on certain versions of TDW. 
+
 ### Example Controllers
 
 - Added: `lights_output_data.py`

--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -27,6 +27,8 @@ To upgrade from TDW v1.7 to v1.8, read [this guide](Documentation/upgrade_guides
 
 ### `tdw` module
 
+- (Backend) Added `packaging` as a required module.
+
 #### `Build` (backend)
 
 - Added optional parameter `check_head` to `get_url()`. If True, check the HTTP headers to make sure that the release exists.

--- a/Documentation/python/build.md
+++ b/Documentation/python/build.md
@@ -8,7 +8,7 @@ Various helper functions for TDW builds.
 
 ***
 
-#### `get_url(version: str = __version__) -> Tuple[str, bool]`
+#### `get_url(version: str = __version__, check_head: bool = True) -> Tuple[str, bool]`
 
 _This is a static function._
 
@@ -16,6 +16,7 @@ _This is a static function._
 | Parameter | Description |
 | --- | --- |
 | version | The version of the build. Default = the installed version of TDW. |
+| check_head | If True, check the HTTP headers to make sure that the release exists. |
 
 _Returns:_  The URL of the build release matching the version and the OS of this machine, True if the URL exists.
 

--- a/Documentation/python/pypi.md
+++ b/Documentation/python/pypi.md
@@ -87,3 +87,19 @@ _Returns:_  The most up-to-date version in this major release. (Example: if v ==
 
 ***
 
+#### `required_tdw_version_is_installed(required_version: str, build_version: str) -> bool`
+
+_This is a static function._
+
+Check whether the correct version of TDW is installed.
+This is useful for other modules such as the Magnebot API that rely on certain versions of TDW.
+
+| Parameter | Description |
+| --- | --- |
+| required_version | The required version of TDW. |
+| build_version | The version of the build. |
+
+_Returns:_  True if both the tdw module is the correct version.
+
+***
+

--- a/Documentation/python/pypi.md
+++ b/Documentation/python/pypi.md
@@ -99,7 +99,7 @@ This is useful for other modules such as the Magnebot API that rely on certain v
 | required_version | The required version of TDW. |
 | build_version | The version of the build. |
 
-_Returns:_  True if both the tdw module is the correct version.
+_Returns:_  True if the installed tdw module is the correct version.
 
 ***
 

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -31,5 +31,5 @@ setup(
     include_package_data=True,
     keywords='unity simulation ml machine-learning',
     install_requires=['pyzmq', 'numpy', 'scipy', 'pillow', 'tqdm', 'psutil', 'boto3', 'botocore', 'requests',
-                      'pyinstaller'],
+                      'pyinstaller', 'packaging'],
 )

--- a/Python/tdw/release/build.py
+++ b/Python/tdw/release/build.py
@@ -22,9 +22,10 @@ class Build:
         BUILD_PATH = BUILD_PATH.joinpath("Contents/MacOS/TDW")
 
     @staticmethod
-    def get_url(version: str = __version__) -> Tuple[str, bool]:
+    def get_url(version: str = __version__, check_head: bool = True) -> Tuple[str, bool]:
         """
         :param version: The version of the build. Default = the installed version of TDW.
+        :param check_head: If True, check the HTTP headers to make sure that the release exists.
 
         :return: The URL of the build release matching the version and the OS of this machine, True if the URL exists.
         """
@@ -36,7 +37,7 @@ class Build:
         else:
             url += ".tar.gz"
         # Check if the URL exists.
-        if head(url).status_code != 302:
+        if check_head and head(url).status_code != 302:
             print(f"Release not found: {url}")
             release_exists = False
         else:

--- a/Python/tdw/release/pypi.py
+++ b/Python/tdw/release/pypi.py
@@ -105,10 +105,10 @@ class PyPi:
         :return: The most up-to-date version in this major release. (Example: if v == 1.5.0, this returns 1.5.5)
         """
 
-        version = PyPi.strip_post_release(v)
+        v = PyPi.strip_post_release(v)
         releases = PyPi._get_pypi_releases()
         # Sort the list by the byte array representation to put double-digit version numbers in the correct order.
-        releases = sorted([r for r in releases if r.startswith("1." + PyPi.get_major_release(version))],
+        releases = sorted([r for r in releases if r.startswith("1." + PyPi.get_major_release(v))],
                           key=lambda r: bytes([int(n) for n in r.split(".")]))
         if len(releases) == 0:
             return ""

--- a/Python/tdw/release/pypi.py
+++ b/Python/tdw/release/pypi.py
@@ -123,7 +123,7 @@ class PyPi:
         :param required_version: The required version of TDW.
         :param build_version: The version of the build.
 
-        :return: True if both the tdw module is the correct version.
+        :return: True if the installed tdw module is the correct version.
         """
 
         ok: bool = True

--- a/Python/tdw/release/pypi.py
+++ b/Python/tdw/release/pypi.py
@@ -2,6 +2,9 @@ from json import loads
 from requests import get
 from typing import List
 from pkg_resources import get_distribution
+from packaging import version
+from tdw.version import __version__
+from tdw.release.build import Build
 
 
 class PyPi:
@@ -110,3 +113,32 @@ class PyPi:
         if len(releases) == 0:
             return ""
         return releases[-1]
+
+    @staticmethod
+    def required_tdw_version_is_installed(required_version: str, build_version: str) -> bool:
+        """
+        Check whether the correct version of TDW is installed.
+        This is useful for other modules such as the Magnebot API that rely on certain versions of TDW.
+
+        :param required_version: The required version of TDW.
+        :param build_version: The version of the build.
+
+        :return: True if both the tdw module is the correct version.
+        """
+
+        ok: bool = True
+        required_version = PyPi.strip_post_release(required_version)
+        if version.parse(required_version) != version.parse(__version__):
+            print(f"WARNING! You have tdw {__version__} but you need tdw {required_version}. "
+                  f"To install the correct version:"
+                  f"\n\tIf you installed tdw from the GitHub repo (pip3 install -e .): "
+                  f"git checkout v{PyPi.strip_post_release(required_version)}"
+                  f"\n\tIf you installed tdw from PyPi (pip3 install tdw): "
+                  f"pip3 install tdw=={required_version}")
+            ok = False
+        if version.parse(build_version) != version.parse(required_version):
+            url, url_exists = Build.get_url(required_version, check_head=False)
+            print(f"WARNING! You are using TDW build {build_version} but you need TDW build {required_version}. "
+                  f"\n\tDownload and extract: {url}")
+            ok = False
+        return ok


### PR DESCRIPTION
### `tdw` module

#### `Build` (backend)

- Added optional parameter `check_head` to `get_url()`. If True, check the HTTP headers to make sure that the release exists.

#### `PyPi` (backend)

- Added: `required_tdw_version_is_installed(required_version, build_version)` Check whether the correct version of TDW is installed. This is useful for other modules such as the Magnebot API that rely on certain versions of TDW. 