### PR TITLE
Fixed: send_occlusion often gives the wrong occlusion value

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -28,6 +28,10 @@ To upgrade from TDW v1.7 to v1.8, read [this guide](Documentation/upgrade_guides
 | -------------------- | ------------------------------ |
 | `SegmentationColors` | Added: `get_object_category()` |
 
+### Build
+
+- Fixed: `send_occlusion` gives a occlusion value of 0 when there is occlusion. This has been fixed but the command is somewhat slower now.
+
 ## v1.8.23
 
 **THIS IS A CRITICAL UPDATE.** You are **strongly** advised to upgrade to this version of TDW.

--- a/Documentation/benchmark/observation_data.md
+++ b/Documentation/benchmark/observation_data.md
@@ -195,7 +195,7 @@ You can infer whether the avatar is "looking at" a given object.
 | `--boxes --images --passes _img`                | 306  |
 | `--boxes --images --passes _id`                 | 230  |
 | `--boxes --id_grayscale --images --passes none` | 316  |
-| `--boxes --occlusion --images --passes none`    | 199  |
+| `--boxes --occlusion --images --passes none`    | 150  |
 | `--boxes --id_colors --images --passes none`    | 180  |
 | `--boxes --transforms`                          | 611  |
 


### PR DESCRIPTION
### Build

- Fixed: `send_occlusion` gives a occlusion value of 0 when there is occlusion. This has been fixed but the command is somewhat slower now.