### PR TITLE
Added optional parameter comparison to required_tdw_version_is_installed()

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -16,6 +16,12 @@ To upgrade from TDW v1.7 to v1.8, read [this guide](Documentation/upgrade_guides
 | `add_force_to_prismatic`  | Add a force to a prismatic joint.  |
 | `add_torque_to_spherical` | Add a torque to a spherical joint. |
 
+### `tdw` module
+
+#### `PyPi`
+
+- (Backend) Added optional parameter `comparison` to `PyPi.required_tdw_version_is_installed()`. Options: `"equals"`, `"greater_than"`, and `"greater_than_or_equals"`.
+
 ### Example Controllers
 
 - Added: `robot_torque.py`

--- a/Documentation/python/pypi.md
+++ b/Documentation/python/pypi.md
@@ -87,7 +87,7 @@ _Returns:_  The most up-to-date version in this major release. (Example: if v ==
 
 ***
 
-#### `required_tdw_version_is_installed(required_version: str, build_version: str) -> bool`
+#### `required_tdw_version_is_installed(required_version: str, build_version`
 
 _This is a static function._
 
@@ -98,6 +98,7 @@ This is useful for other modules such as the Magnebot API that rely on certain v
 | --- | --- |
 | required_version | The required version of TDW. |
 | build_version | The version of the build. |
+| comparison | The type of comparison. Options: "equals", "greater_than", "greater_than_or_equals". |
 
 _Returns:_  True if the installed tdw module is the correct version.
 

--- a/Documentation/python/pypi.md
+++ b/Documentation/python/pypi.md
@@ -87,7 +87,7 @@ _Returns:_  The most up-to-date version in this major release. (Example: if v ==
 
 ***
 
-#### `required_tdw_version_is_installed(required_version: str, build_version`
+#### `required_tdw_version_is_installed(required_version: str, build_version: str, comparison: str = "equals") -> bool`
 
 _This is a static function._
 

--- a/Python/tdw/release/pypi.py
+++ b/Python/tdw/release/pypi.py
@@ -115,20 +115,30 @@ class PyPi:
         return releases[-1]
 
     @staticmethod
-    def required_tdw_version_is_installed(required_version: str, build_version: str) -> bool:
+    def required_tdw_version_is_installed(required_version: str, build_version: str,
+                                          comparison: str = "equals") -> bool:
         """
         Check whether the correct version of TDW is installed.
         This is useful for other modules such as the Magnebot API that rely on certain versions of TDW.
 
         :param required_version: The required version of TDW.
         :param build_version: The version of the build.
+        :param comparison: The type of comparison. Options: "equals", "greater_than", "greater_than_or_equals".
 
         :return: True if the installed tdw module is the correct version.
         """
 
+        valid_comparisons: List[str] = ["equals", "greater_than", "greater_than_or_equals"]
+        if comparison not in valid_comparisons:
+            raise Exception(f"Invalid comparison {comparison}. Options are: {valid_comparisons}")
+
         ok: bool = True
         required_version = PyPi.strip_post_release(required_version)
-        if version.parse(required_version) != version.parse(__version__):
+        required_version_parsed = version.parse(required_version)
+        installed_version_parsed = version.parse(__version__)
+        if (comparison == "equals" and required_version_parsed != installed_version_parsed) or \
+                (comparison == "greater_than" and installed_version_parsed <= required_version_parsed) or \
+                (comparison == "greater_than_or_equals" and installed_version_parsed < required_version_parsed):
             print(f"WARNING! You have tdw {__version__} but you need tdw {required_version}. "
                   f"To install the correct version:"
                   f"\n\tIf you installed tdw from the GitHub repo (pip3 install -e .): "
@@ -136,7 +146,10 @@ class PyPi:
                   f"\n\tIf you installed tdw from PyPi (pip3 install tdw): "
                   f"pip3 install tdw=={required_version}")
             ok = False
-        if version.parse(build_version) != version.parse(required_version):
+        build_version_parsed = version.parse(build_version)
+        if (comparison == "equals" and build_version_parsed != required_version_parsed) or \
+                (comparison == "greater_than" and build_version_parsed <= required_version_parsed) or \
+                (comparison == "greater_than_or_equals" and build_version_parsed < required_version_parsed):
             url, url_exists = Build.get_url(required_version, check_head=False)
             print(f"WARNING! You are using TDW build {build_version} but you need TDW build {required_version}. "
                   f"\n\tDownload and extract: {url}")

--- a/Python/tdw/release/pypi.py
+++ b/Python/tdw/release/pypi.py
@@ -115,8 +115,7 @@ class PyPi:
         return releases[-1]
 
     @staticmethod
-    def required_tdw_version_is_installed(required_version: str, build_version: str,
-                                          comparison: str = "equals") -> bool:
+    def required_tdw_version_is_installed(required_version: str, build_version: str, comparison: str = "equals") -> bool:
         """
         Check whether the correct version of TDW is installed.
         This is useful for other modules such as the Magnebot API that rely on certain versions of TDW.


### PR DESCRIPTION
### `tdw` module

#### `PyPi`

- (Backend) Added optional parameter `comparison` to `PyPi.required_tdw_version_is_installed()`. Options: `"equals"`, `"greater_than"`, and `"greater_than_or_equals"`.