### PR TITLE
Removed Controller.start()

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -70,9 +70,10 @@ To upgrade from TDW v1.8 to v1.9, read [this guide](Documentation/upgrade_guides
 
 #### `Controller`
 
-- Added: `Controller.add_ons` A list of add-ons that will inject commands every time `communicate()` is called.
-- Removed: `Controller.add_object(model_name)` Use `Controller.get_add_object(model_name)` instead.
-- Removed: `Controller.load_streamed_scene(scene)` Use `Controller.get_add_scene(scene_name)` instead.
+- **Added: `Controller.add_ons`** A list of add-ons that will inject commands every time `communicate()` is called.
+- **Removed: `Controller.start()`** The command it used to send is automatically sent in the Controller constructor. 
+- **Removed: `Controller.add_object(model_name)`** Use `Controller.get_add_object(model_name)` instead.
+- **Removed: `Controller.load_streamed_scene(scene)`** Use `Controller.get_add_scene(scene_name)` instead.
 - Removed `check_build_process` from the constructor because it's too slow to be useful.
 
 #### `FloorplanController`

--- a/Documentation/python/controller.md
+++ b/Documentation/python/controller.md
@@ -40,16 +40,6 @@ _Returns:_ The output data from the build.
 
 ***
 
-#### `start(self, scene="ProcGenScene") -> None`
-
-This function has been deprecated and doesn't do anything. It will be removed in TDW v1.10.
-
-| Parameter | Description |
-| --- | --- |
-| scene | The scene to load. |
-
-***
-
 #### `get_add_object(self, model_name: str, object_id: int, position={"x": 0, "y": 0, "z": 0}, rotation={"x": 0, "y": 0, "z": 0}, library: str = "") -> dict`
 
 Returns a valid add_object command.

--- a/Documentation/python/controller.md
+++ b/Documentation/python/controller.md
@@ -42,7 +42,7 @@ _Returns:_ The output data from the build.
 
 #### `start(self, scene="ProcGenScene") -> None`
 
-Init TDW.
+This function has been deprecated and doesn't do anything. It will be removed in TDW v1.10.
 
 | Parameter | Description |
 | --- | --- |

--- a/Documentation/upgrade_guides/v1.8_to_v1.9.md
+++ b/Documentation/upgrade_guides/v1.8_to_v1.9.md
@@ -6,7 +6,7 @@
 
 ## 1. Changes to the `tdw` module
 
-### Remove `Controller.start()`
+### Removed `Controller.start()`
 
 This function used to send a command to initialize a scene in TDW. Now, that command is sent automatically in the Controller constructor.
 

--- a/Documentation/upgrade_guides/v1.8_to_v1.9.md
+++ b/Documentation/upgrade_guides/v1.8_to_v1.9.md
@@ -6,6 +6,31 @@
 
 ## 1. Changes to the `tdw` module
 
+### Remove `Controller.start()`
+
+This function used to send a command to initialize a scene in TDW. Now, that command is sent automatically in the Controller constructor.
+
+In v1.8:
+
+```python
+from tdw.controller import Controller
+from tdw.tdw_utils import TDWUtils
+
+c = Controller()
+c.start()
+c.communicate(TDWUtils.create_empty_room(12, 12))
+```
+
+In v1.9:
+
+```python
+from tdw.controller import Controller
+from tdw.tdw_utils import TDWUtils
+
+c = Controller()
+c.communicate(TDWUtils.create_empty_room(12, 12))
+```
+
 ### Removed `Controller.load_streamed_scene(scene)`
 
 This function hasn't been the preferred way to load a stream scene for a while now because it doesn't let you send additional commands on the same frame. We recommend using `Controller.get_add_scene(scene_name)` instead.

--- a/Python/tdw/controller.py
+++ b/Python/tdw/controller.py
@@ -56,7 +56,9 @@ class Controller(object):
         # Set error handling to default values (the build will try to quit on errors and exceptions).
         # Request the version to log it and remember here if the Editor is being used.
         resp = self.communicate([{"$type": "set_error_handling"},
-                                 {"$type": "send_version"}])
+                                 {"$type": "send_version"},
+                                 {"$type": "load_scene",
+                                  "scene_name": "ProcGenScene"}])
         self._is_standalone: bool = False
         self._tdw_version: str = ""
         self._unity_version: str = ""
@@ -152,12 +154,15 @@ class Controller(object):
 
     def start(self, scene="ProcGenScene") -> None:
         """
-        Init TDW.
+        This function has been deprecated and doesn't do anything. It will be removed in TDW v1.10.
 
         :param scene: The scene to load.
         """
 
-        self.communicate([{"$type": "load_scene", "scene_name": scene}])
+        print("This function has been deprecated and doesn't do anything. "
+              "The command it used to send is automatically sent via the Controller constructor. "
+              "You can safely remove this function from your code. "
+              "The start() function will be removed in TDW v1.10")
 
     def get_add_object(self, model_name: str, object_id: int, position={"x": 0, "y": 0, "z": 0}, rotation={"x": 0, "y": 0, "z": 0}, library: str = "") -> dict:
         """

--- a/Python/tdw/controller.py
+++ b/Python/tdw/controller.py
@@ -152,18 +152,6 @@ class Controller(object):
         # Return the output data from the build.
         return resp
 
-    def start(self, scene="ProcGenScene") -> None:
-        """
-        This function has been deprecated and doesn't do anything. It will be removed in TDW v1.10.
-
-        :param scene: The scene to load.
-        """
-
-        print("This function has been deprecated and doesn't do anything. "
-              "The command it used to send is automatically sent via the Controller constructor. "
-              "You can safely remove this function from your code. "
-              "The start() function will be removed in TDW v1.10")
-
     def get_add_object(self, model_name: str, object_id: int, position={"x": 0, "y": 0, "z": 0}, rotation={"x": 0, "y": 0, "z": 0}, library: str = "") -> dict:
         """
         Returns a valid add_object command.


### PR DESCRIPTION
**Removed `Controller.start()`** 

This function used to send a command to initialize a scene in TDW. Now, that command is sent automatically in the Controller constructor.

Note that this PR updates the API doc, the upgrade doc, and the changelog, but none of the tutorials or example controllers. Those will be addressed in a separate PR off of the documentation_v2 branch (as opposed to this PR which is off of the v1.9_wip branch).

In v1.8:

```python
from tdw.controller import Controller
from tdw.tdw_utils import TDWUtils

c = Controller()
c.start()
c.communicate(TDWUtils.create_empty_room(12, 12))
```

In v1.9:

```python
from tdw.controller import Controller
from tdw.tdw_utils import TDWUtils

c = Controller()
c.communicate(TDWUtils.create_empty_room(12, 12))
```