### PR TITLE
Fixed: set_kinematic_state only affects root of composite objects

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -10,9 +10,10 @@ To upgrade from TDW v1.7 to v1.8, read [this guide](Documentation/upgrade_guides
 
 #### Modified Commands
 
-| Command                                       | Description                                                  |
+| Command                                       | Modification                                                 |
 | --------------------------------------------- | ------------------------------------------------------------ |
 | `play_audio_data`<br>`play_point_source_data` | Fixed: Unhandled exception if one of the objects is a robot joint. |
+| `set_kinematic_state`                         | Fixed: If the object is a composite object, only the root object is set. |
 
 ### `tdw` module
 


### PR DESCRIPTION
# How to test

1. In `TDWBase`, `git fetch` and `git checkout set_composite_object_kinematic`
2. Write a controller that adds a composite object + `set_kinematic_state`. Set `launch_build=False`
3. Launch the controller
4. Launch the build in Unity Editor

Result: The composite object doesn't move.