### PR TITLE
Fix bug when loading local library

### DIFF
--- a/Python/tdw/object_init_data.py
+++ b/Python/tdw/object_init_data.py
@@ -89,7 +89,7 @@ class TransformInitData:
         :return: The model metadata record for this object.
         """
 
-        return TransformInitData.LIBRARIES[self.library].get_record(name=self.name)
+        return ModelLibrarian(self.library).get_record(name=self.name)
 
 
 class RigidbodyInitData(TransformInitData):


### PR DESCRIPTION
Hi, I found some codes are programmed that forbid users to load their own model library, since `ModelLibrarian.get_library_filenames()` can only get some of the pre-defined library files. In my case, I created a local json file to store the location of models, but ran into an error when trying to "get_record". I fixed it by changing this line. So far it works well. 