### PR TITLE
Fixed: Roll events are now registered as impact events

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -4,6 +4,12 @@
 
 To upgrade from TDW v1.8 to v1.9, read [this guide](upgrade_guides/v1.8_to_v1.9.md).
 
+## v1.9.1
+
+### `tdw` module
+
+- Fixed: `PyImpact` seems to be "missing" impact sounds because roll sounds haven't been implemented yet. Now, all "roll" events are handled as "impact events".
+
 ## v1.9.0
 
 ### New Features

--- a/Python/tdw/physics_audio/collision_audio_event.py
+++ b/Python/tdw/physics_audio/collision_audio_event.py
@@ -123,7 +123,8 @@ class CollisionAudioEvent:
                     angular_velocity = object_0_dynamic.angular_velocity
                 # If the primary object has a high angular velocity, this is a roll.
                 if np.linalg.norm(angular_velocity) > CollisionAudioEvent.ROLL_ANGULAR_VELOCITY:
-                    self.collision_type = CollisionAudioType.roll
+                    # TODO set this to CollisionAudioType.roll once we have roll sounds.
+                    self.collision_type = CollisionAudioType.impact
                 # If the primary object has a low angular velocity, this is a scrape.
                 else:
                     self.collision_type = CollisionAudioType.scrape


### PR DESCRIPTION
### `tdw` module

- Fixed: `PyImpact` seems to be "missing" impact sounds because roll sounds haven't been implemented yet. Now, all "roll" events are handled as "impact events".