### PR TITLE
Fixed example controllers in custom_models.md

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -41,6 +41,14 @@ To upgrade from TDW v1.8 to v1.9, read [this guide](upgrade_guides/v1.8_to_v1.9.
 - Flagged models as do_not_use in `models_core.json`: coffeecup004, mug, salt
 - Flagged models as do_not_use in `models_full.json`: coffeecup004, mug, salt, b03_closed_soda_can, b04_chocolate, b04_coffee_grinder_sunbeam_em0700, b04_glass, b04_whyskeyglass, b05_beko_oie_22500x_2013_corona, croissant, jar, peppermill, pineapple_juice, pineapple_juice_carton, spagheti-server, b03_can-opened
 
+### Documentation
+
+#### Modified Documentation
+
+| Document                             | Modification                                                 |
+| ------------------------------------ | ------------------------------------------------------------ |
+| `lessons/3d_models/custom_models.md` | Fixed: Two of the example controllers don't work because they try to load JSON from the file path rather than the file text. |
+
 ## v1.9.0
 
 ### New Features

--- a/Documentation/lessons/3d_models/custom_models.md
+++ b/Documentation/lessons/3d_models/custom_models.md
@@ -176,7 +176,7 @@ from tdw.tdw_utils import TDWUtils
 from tdw.librarian import ModelRecord
 
 model_name = "chair"
-model_record = ModelRecord(loads(Path.home().joinpath("tdw_asset_bundles/chair/record.json")))
+model_record = ModelRecord(loads(Path.home().joinpath("tdw_asset_bundles/chair/record.json").read_text()))
 c = Controller()
 c.communicate([TDWUtils.create_empty_room(12, 12),
                {"$type": "add_object",
@@ -212,7 +212,7 @@ from tdw.librarian import ModelLibrarian, ModelRecord
 # Convert from a relative to absolute path to load the librarian.
 librarian = ModelLibrarian(library=str(Path("models_custom.json").resolve()))
 
-record = ModelRecord(loads(Path.home().joinpath("tdw_asset_bundles/chair/record.json")))
+record = ModelRecord(loads(Path.home().joinpath("tdw_asset_bundles/chair/record.json").read_text()))
 
 librarian.add_or_update_record(record=record, overwrite=False, write=True)
 ```


### PR DESCRIPTION
This is a revision of [this PR](https://github.com/threedworld-mit/tdw/pull/329) that uses the JSON deserialization syntax used elsewhere in the documentation, i.e. using `Path.read_text()`