### PR TITLE
Added: TDWUtils.get_circle_mask()

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -29,6 +29,7 @@ To upgrade from TDW v1.8 to v1.9, read [this guide](upgrade_guides/v1.8_to_v1.9.
 - Replaced `resonance` parameter in all `PyImpact` functions with `primary_resonance` and `secondary_resonance` parameters.
 - Adjusted some default static object audio values.
 - Added: `TDWUtils.bytes_to_megabytes(b)` Convert a quantity of bytes to a quantity of megabytes.
+- Added: `TDWUtils.get_circle_mask(arr, row, column, radius)`. Get elements in an array within a circle.
 - Added: `QuaternionUtils.is_left_of(origin, target, forward)` Returns True if `target` is to the left of `origin` otherwise returns False.
 - Modifed `TDWUtils.get_bounds_extents`:
   - The function now accepts either `Bounds` output data or a cached bounds dictionary from `record.bounds` (in which case the `index` parameter is ignored).

--- a/Documentation/python/tdw_utils.md
+++ b/Documentation/python/tdw_utils.md
@@ -594,3 +594,21 @@ _This is a static function._
 
 _Returns:_  A quantity of megabytes.
 
+#### get_circle_mask
+
+**`TDWUtils.get_circle_mask(shape, row, column, radius)`**
+
+_This is a static function._
+
+Get elements in an array within a circle.
+
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| shape |  Tuple[int, int] |  | The shape of the source array as (rows, columns). |
+| row |  int |  | The row (axis 0) of the center of the circle. |
+| column |  int |  | The column (axis 1) of the circle. |
+| radius |  int |  | The radius of the circle in indices. |
+
+_Returns:_  A boolean array with shape `shape`. Elements that are True are within the circle.
+

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from pathlib import Path
 import re
 
-__version__ = "1.9.1.2"
+__version__ = "1.9.1.3"
 readme_path = Path('../README.md')
 if readme_path.exists():
     long_description = readme_path.read_text(encoding='utf-8')

--- a/Python/tdw/tdw_utils.py
+++ b/Python/tdw/tdw_utils.py
@@ -734,3 +734,21 @@ class TDWUtils:
         """
 
         return b / (1 << 20)
+
+    @staticmethod
+    def get_circle_mask(shape: Tuple[int, int], row: int, column: int, radius: int) -> np.array:
+        """
+        Get elements in an array within a circle.
+
+        :param shape: The shape of the source array as (rows, columns).
+        :param row: The row (axis 0) of the center of the circle.
+        :param column: The column (axis 1) of the circle.
+        :param radius: The radius of the circle in indices.
+
+        :return: A boolean array with shape `shape`. Elements that are True are within the circle.
+        """
+
+        # Source: https://www.semicolonworld.com/question/44279/how-to-apply-a-disc-shaped-mask-to-a-numpy-array
+        nx, ny = shape
+        oy, ox = np.ogrid[-row:nx - row, -column:ny - column]
+        return ox * ox + oy * oy <= radius * radius


### PR DESCRIPTION
Added: `TDWUtils.get_circle_mask(arr, row, column, radius)`. Get elements in an array within a circle.