### PR TITLE
Fixed: TDWUtils.get_pil_images() doesn't work for _depth or _depth_simple

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -34,6 +34,7 @@ To upgrade from TDW v1.8 to v1.9, read [this guide](upgrade_guides/v1.8_to_v1.9.
 - Modifed `TDWUtils.get_bounds_extents`:
   - The function now accepts either `Bounds` output data or a cached bounds dictionary from `record.bounds` (in which case the `index` parameter is ignored).
   - The order of the returned array is: width, height, length (was width, length, height).
+- Fixed: `TDWUtils.get_pil_images()` doesn't work for `_depth` or `_depth_simple`.
 
 
 ### Model library

--- a/Python/tdw/tdw_utils.py
+++ b/Python/tdw/tdw_utils.py
@@ -324,7 +324,13 @@ class TDWUtils:
         :return A PIL image.
         """
 
-        return Image.open(io.BytesIO(images.get_image(index)))
+        pass_mask = images.get_pass_mask(index)
+        # The depth passes aren't png files, so we need to convert them.
+        if pass_mask == "_depth" or pass_mask == "_depth_simple":
+            # Save the image.
+            return Image.fromarray(TDWUtils.get_shaped_depth_pass(images=images, index=index))
+        else:
+            return Image.open(io.BytesIO(images.get_image(index)))
 
     @staticmethod
     def get_random_position_on_nav_mesh(c: Controller, width: float, length: float, x_e=0, z_e=0, bake=True, rng=random.uniform) -> Tuple[float, float, float]:

--- a/Python/tdw/tdw_utils.py
+++ b/Python/tdw/tdw_utils.py
@@ -325,9 +325,7 @@ class TDWUtils:
         """
 
         pass_mask = images.get_pass_mask(index)
-        # The depth passes aren't png files, so we need to convert them.
         if pass_mask == "_depth" or pass_mask == "_depth_simple":
-            # Save the image.
             return Image.fromarray(TDWUtils.get_shaped_depth_pass(images=images, index=index))
         else:
             return Image.open(io.BytesIO(images.get_image(index)))


### PR DESCRIPTION
See: https://github.com/threedworld-mit/tdw/pull/332/files

This PR fixes the bug in `TDWUtils` as opposed to `ImageCapture`

Example controller:

```python
from tdw.controller import Controller
from tdw.tdw_utils import TDWUtils
from tdw.add_ons.third_person_camera import ThirdPersonCamera
from tdw.add_ons.image_capture import ImageCapture
from tdw.backend.paths import EXAMPLE_CONTROLLER_OUTPUT_PATH

c = Controller()
camera = ThirdPersonCamera(position={"x": 0, "y": 1, "z": 0},
                           avatar_id="a")
capture = ImageCapture(avatar_ids=["a"],
                       pass_masks=["_img", "_depth"],
                       path=EXAMPLE_CONTROLLER_OUTPUT_PATH.joinpath("depth_pil"))
c.add_ons.extend([camera, capture])
c.communicate(TDWUtils.create_empty_room(12, 12))
capture.get_pil_images()["a"]["_depth"].show()
c.communicate({"$type": "terminate"})
```