### PR TITLE
Added a section about exporting fbx files in meters

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -16,6 +16,14 @@ To upgrade from TDW v1.8 to v1.9, read [this guide](upgrade_guides/v1.8_to_v1.9.
 | `set_hinge_limits` | Set the angle limits of a hinge joint. This will work with hinges, motors, and springs. |
 | `set_object_physics_solver_iterations` | Set the physics solver iterations for an object, which affects its overall accuracy of the physics engine. |
 
+### Documentation
+
+#### Modified Documentation
+
+| Document                             | Modification                                                 |
+| ------------------------------------ | ------------------------------------------------------------ |
+| `lessons/3d_models/custom_models.md` | Added a section regarding .fbx unit scales; .fbx files must be in meters. |
+
 ## v1.9.1
 
 ### Command API

--- a/Documentation/lessons/3d_models/custom_models.md
+++ b/Documentation/lessons/3d_models/custom_models.md
@@ -235,6 +235,10 @@ You could convert many models to asset bundles by creating a loop that repeatedl
 
 Instead, consider using `create_many_asset_bundles(library_path)` for large numbers of models. This function will walk through `asset_bundle_creator/Assets/Resources/models/` searching for .obj and .fbx models. It will convert these models to asset bundles.
 
+## .fbx unit scale
+
+The unit scale of the source .fbx file must be meters. If not, the physics colliders will likely be at the wrong scale.
+
 ## Export .fbx files from Blender 2.8
 
 Blender can be fussy when exporting to Unity. If you export a .obj, you shouldn't have any problems. If you export a .fbx, there may be problems with the model's scale, as well as the collider's scale.

--- a/Documentation/lessons/3d_models/custom_models.md
+++ b/Documentation/lessons/3d_models/custom_models.md
@@ -237,7 +237,7 @@ Instead, consider using `create_many_asset_bundles(library_path)` for large numb
 
 ## .fbx unit scale
 
-The unit scale of the source .fbx file must be meters. If not, the physics colliders will likely be at the wrong scale.
+The unit scale of the exported .fbx file must be meters. If not, the physics colliders will likely be at the wrong scale.
 
 ## Export .fbx files from Blender 2.8
 


### PR DESCRIPTION
### Documentation

#### Modified Documentation

| Document                             | Modification                                                 |
| ------------------------------------ | ------------------------------------------------------------ |
| `lessons/3d_models/custom_models.md` | Added a section regarding .fbx unit scales; .fbx files must be in meters. |