### PR TITLE
Handle unexpected paths in AssetBundleCreator and RobotCreator

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -22,6 +22,14 @@ To upgrade from TDW v1.8 to v1.9, read [this guide](upgrade_guides/v1.8_to_v1.9.
 | ------------------- | ------------------------------------------------------------ |
 | `send_model_report` | Added tests for prismatic joint mechanisms (ConfigureableJoint components) |
 
+### `tdw` module
+
+- Added optional parameter `unity_editor_path` to the `AssetBundleCreator`constructor to optionally explicitly set the path to the Unity Editor executable.
+- Added: `AssetBundleCreator.cleanup()` Clean up intermediary files.
+- Added optional parameter `unity_editor_path` to the `RobotCreator`constructor to optionally explicitly set the path to the Unity Editor executable.
+- Changed the names of all undocumented fields in `AssetBundleCreator` and `RobotCreator` to private (added an `_` to the start of the variable names).
+- Added optional parameters `description_infix` and `branch` to `RobotCreator.create_asset_bundles()` to handle unexpected .urdf URLs.
+
 ### Build
 
 - Added new composite object mechanism type: `prismatic_joint`
@@ -37,7 +45,8 @@ To upgrade from TDW v1.8 to v1.9, read [this guide](upgrade_guides/v1.8_to_v1.9.
 | Document                             | Modification                                                 |
 | ------------------------------------ | ------------------------------------------------------------ |
 | `lessons/physx/composite_objects.md` | Added example code for setting kinematic states of sub-objects. |
-| `lessons/3d_models/custom_models.md` | Added a section regarding .fbx unit scales; .fbx files must be in meters. |
+| `lessons/3d_models/custom_models.md` | Added a section regarding .fbx unit scales; .fbx files must be in meters.<br>Added a section explaining how to manually set the Unity Editor path. |
+| `lessons/robots/custom_robots.md`    | Added a section explaining how to manually set the Unity Editor path. |
 
 #### Removed Documentation
 

--- a/Documentation/lessons/3d_models/custom_models.md
+++ b/Documentation/lessons/3d_models/custom_models.md
@@ -11,8 +11,9 @@ It is possible to add any 3D model to TDW. However, the underlying Unity engine 
 - The `tdw` module
 - Python 3.6+
 - Unity Hub
-- Unity Editor 2020.3.24f1 (installed via Unity Hub)
+- Unity Editor 2020.3.24f1
   - Build options must enabled for Windows, OS X, and Linux (these can  be set when installing Unity).
+  - Ideally, Unity Editor should be installed via Unity Hub; otherwise, you'll need to add the `unity_editor_path` parameter to the `AssetBundleCreator` constructor (see below).
 - A .fbx or .obj+.mtl model
 
 ## The `AssetBundleCreator`
@@ -55,7 +56,19 @@ asset_bundle_paths, record_path = a.create_asset_bundle(model_path=model_path,
                                                         wcategory=wcategory)
 ```
 
- There is one other optional parameter, `scale`, which should usually be set to 1 (the default value). Setting it to another value will scale the model by this factor whenever it is instantiated in TDW.
+There is one other optional parameter, `scale`, which should usually be set to 1 (the default value). Setting it to another value will scale the model by this factor whenever it is instantiated in TDW.
+
+### Unity Editor path
+
+If you installed Unity Editor via Unity Hub, `AssetBundleCreator` should be able to automatically find the Unity Editor executable.
+
+If the Unity Editor executable is in an unexpected location, you will need to explicitly set its location in the `AssetBundleCreator` by setting the optional `unity_editor_path` parameter:
+
+```python
+from tdw.asset_bundle_creator import AssetBundleCreatorBase
+
+a = AssetBundleCreatorBase(quiet=True, unity_editor_path="D:/Unity/2020.3.24f1/Editor/Unity.exe")
+```
 
 ### Intermediate API calls
 

--- a/Documentation/lessons/robots/custom_robots.md
+++ b/Documentation/lessons/robots/custom_robots.md
@@ -10,7 +10,9 @@ The `RobotCreator` can download a .urdf or .xacro file plus all relevant texture
 
 - Windows 10, OS X, or Linux
   - On a remote Linux server, you'll need a valid virtual display (see the `display` parameter of the constructor)
-- Unity Editor 2020.3.24f1 (must be installed via Unity Hub)
+- Unity Editor 2020.3.24f1
+  - Ideally, Unity Editor should be installed via Unity Hub; otherwise, you'll need to add the `unity_editor_path` parameter to the `RobotCreator` constructor (see below).
+
 - Python3 and the `tdw` module
 - git
 
@@ -72,6 +74,18 @@ print(record.urls)
 ```
 
 The first time that this script is run, it will clone [the robot_creator repo](https://github.com/alters-mit/robot_creator) (a Unity project used for creating robots) to your home directory.
+
+### Unity Editor path
+
+If you installed Unity Editor via Unity Hub, `RobotCreator` should be able to automatically find the Unity Editor executable.
+
+If the Unity Editor executable is in an unexpected location, you will need to explicitly set its location in the `RobotCreator` by setting the optional `unity_editor_path` parameter:
+
+```python
+from tdw.robot_creator import RobotCreator
+
+a = RobotCreator(quiet=True, unity_editor_path="D:/Unity/2020.3.24f1/Editor/Unity.exe")
+```
 
 ## Edit the prefab
 

--- a/Documentation/python/asset_bundle_creator.md
+++ b/Documentation/python/asset_bundle_creator.md
@@ -34,12 +34,13 @@ For more information, see: `Documentation/misc_frontend/add_local_object.md`.
 
 **`AssetBundleCreator()`**
 
-**`AssetBundleCreator(quiet=False, display="0")`**
+**`AssetBundleCreator(quiet=False, display="0", unity_editor_path=None)`**
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | quiet |  bool  | False | If true, don't print any messages to console. |
 | display |  str  | "0" | The display to launch Unity Editor on. Ignored if this isn't Linux. |
+| unity_editor_path |  Union[Path, str] | None | The path to the Unity Editor executable, for example `C:/Program Files/Unity/Hub/Editor/2020.3.24f1/Editor/Unity.exe`. If None, this script will try to find Unity Editor automatically. |
 
 #### create_asset_bundle
 
@@ -302,6 +303,12 @@ This function will create collider .obj files if there aren't any already
 | library_path |  str |  | The path to the library file. |
 | cleanup |  bool  | True | If true, remove all temp files when done. |
 | vhacd_resolution |  int  | 8000000 | The V-HACD voxel resolution. A higher number will create more accurate physics colliders, but it will take more time to initially create the asset bundle. |
+
+#### cleanup
+
+**`self.cleanup()`**
+
+Delete all files from `~/asset_bundle_creator` with these extensions: .obj, .fbx, .mtl, .mat, .jpg, .prefab
 
 #### get_unity_project
 

--- a/Documentation/python/asset_bundle_creator_base.md
+++ b/Documentation/python/asset_bundle_creator_base.md
@@ -20,12 +20,13 @@ Base class for creating asset bundles.
 
 **`AssetBundleCreatorBase()`**
 
-**`AssetBundleCreatorBase(quiet=False, display="0")`**
+**`AssetBundleCreatorBase(quiet=False, display="0", unity_editor_path=None)`**
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| quiet |  bool  | False | If true, don't print any messages to console. |
+| quiet |  bool  | False | If True, don't print any messages to console. |
 | display |  str  | "0" | The display to launch Unity Editor on. Ignored if this isn't Linux. |
+| unity_editor_path |  Union[Path, str] | None | The path to the Unity Editor executable, for example `C:/Program Files/Unity/Hub/Editor/2020.3.24f1/Editor/Unity.exe`. If None, this script will try to find Unity Editor automatically. |
 
 #### get_base_unity_call
 

--- a/Documentation/python/robot_creator.md
+++ b/Documentation/python/robot_creator.md
@@ -20,18 +20,19 @@ Download a .urdf or .xacro file and convert it into an asset bundle that is usab
 
 **`RobotCreator()`**
 
-**`RobotCreator(quiet=False, display="0")`**
+**`RobotCreator(quiet=False, display="0", unity_editor_path=None)`**
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | quiet |  bool  | False | If true, don't print any messages to console. |
 | display |  str  | "0" | The display to launch Unity Editor on. Ignored if this isn't Linux. |
+| unity_editor_path |  Union[Path, str] | None | The path to the Unity Editor executable, for example `C:/Program Files/Unity/Hub/Editor/2020.3.24f1/Editor/Unity.exe`. If None, this script will try to find Unity Editor automatically. |
 
 #### create_asset_bundles
 
 **`self.create_asset_bundles(urdf_url)`**
 
-**`self.create_asset_bundles(urdf_url, required_repo_urls=None, xacro_args=None, immovable=True, up="y")`**
+**`self.create_asset_bundles(urdf_url, required_repo_urls=None, xacro_args=None, immovable=True, up="y", description_infix=None, branch=None)`**
 
 Given the URL of a .urdf file or a .xacro file, create asset bundles of the robot.
 
@@ -50,6 +51,8 @@ This is a wrapper function for:
 | xacro_args |  Dict[str, str] | None | Names and values for the `arg` tags in the .xacro file (ignored if this is a .urdf file). For example, the Sawyer robot requires this to add the gripper: `{"electric_gripper": "true"}` |
 | immovable |  bool  | True | If True, the base of the robot is immovable. |
 | up |  str  | "y" | The up direction. Used when importing the robot into Unity. Options: `"y"` or `"z"`. Usually, this should be the default value (`"y"`). |
+| description_infix |  str  | None | The name of the description infix within the .urdf URL, such as `fetch_description`. Only set this if the urdf URL is non-standard; otherwise `RobotCreator` should be able to find this automatically. |
+| branch |  str  | None | The name of the branch of the repo. If None, defaults to `"master"`. |
 
 _Returns:_  A `RobotRecord` object. The `urls` field contains the paths to each asset bundle.
 
@@ -86,7 +89,7 @@ _Returns:_  The temporary directory.
 
 **`self.copy_files(urdf_url, local_repo_path, repo_paths)`**
 
-**`self.copy_files(urdf_url, local_repo_path, repo_paths, xacro_args=None)`**
+**`self.copy_files(urdf_url, local_repo_path, repo_paths, xacro_args=None, branch=None)`**
 
 Copy and convert files required to create a prefab.
 
@@ -101,6 +104,7 @@ Copy and convert files required to create a prefab.
 | local_repo_path |  Path |  | The path to the local repo. |
 | repo_paths |  Dict[str, Path] |  | A dictionary of required repos (including the one that the .urdf or .xacro is in). Key = The description path infix, e.g. "sawyer_description". Value = The path to the local repo. |
 | xacro_args |  Dict[str, str] | None | Names and values for the `arg` tags in the .xacro file. Can be None for a .urdf or .xacro file and always ignored for a .urdf file. |
+| branch |  str  | None | The name of the branch of the repo. If None, defaults to `"master"`. |
 
 _Returns:_  The path to the .urdf file in the Unity project.
 

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from pathlib import Path
 import re
 
-__version__ = "1.9.2.0"
+__version__ = "1.9.2.1"
 readme_path = Path('../README.md')
 if readme_path.exists():
     long_description = readme_path.read_text(encoding='utf-8')

--- a/Python/tdw/asset_bundle_creator_base.py
+++ b/Python/tdw/asset_bundle_creator_base.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
 import platform
-from typing import List
+from typing import List, Union
 from subprocess import check_output, CalledProcessError
 import os
 import re
@@ -17,16 +17,17 @@ class AssetBundleCreatorBase(ABC):
     """
     UNITY_VERSION: str = "2020.3"
 
-    def __init__(self, quiet: bool = False, display: str = ":0"):
+    def __init__(self, quiet: bool = False, display: str = ":0", unity_editor_path: Union[Path, str] = None):
         """
-        :param quiet: If true, don't print any messages to console.
+        :param quiet: If True, don't print any messages to console.
         :param display: The display to launch Unity Editor on. Ignored if this isn't Linux.
+        :param unity_editor_path: The path to the Unity Editor executable, for example `C:/Program Files/Unity/Hub/Editor/2020.3.24f1/Editor/Unity.exe`. If None, this script will try to find Unity Editor automatically.
         """
 
         # Get the binaries path and verify that AssetBundleCreator will work on this platform.
         system = platform.system()
 
-        self.env = os.environ.copy()
+        self._env = os.environ.copy()
 
         # libgconf needs to be installed the Editor to work.
         if system == "Linux":
@@ -35,23 +36,31 @@ class AssetBundleCreatorBase(ABC):
             except CalledProcessError as e:
                 raise Exception(f"{e}\n\nRun: sudo apt install libgconf-2-4")
             # Set the display for Linux.
-            self.env["DISPLAY"] = display
-
-        self.quiet = quiet
-
-        self.project_path = self.get_unity_project()
-        assert self.project_path.exists(), self.project_path
-
-        self.unity_call = self.get_base_unity_call()
+            self._env["DISPLAY"] = display
+        self._quiet: bool = quiet
+        self._project_path: Path = self.get_unity_project()
+        assert self._project_path.exists(), self._project_path
+        # Get the Unity path.
+        if unity_editor_path is None:
+            self._unity_editor_path: Path = AssetBundleCreatorBase.get_editor_path()
+        else:
+            if isinstance(unity_editor_path, Path):
+                self._unity_editor_path = unity_editor_path
+            elif isinstance(unity_editor_path, str):
+                self._unity_editor_path = Path(unity_editor_path)
+            else:
+                raise Exception(f"Invalid Unity editor path: {self._unity_editor_path}")
+            assert self._unity_editor_path.exists(), "Unity Editor not found: " + str(self._unity_editor_path.resolve())
+        self._unity_call: List[str] = self.get_base_unity_call()
 
     def get_base_unity_call(self) -> List[str]:
         """
         :return The call to launch Unity Editor silently in batchmode, execute something, and then quit.
         """
 
-        return [str(AssetBundleCreatorBase.get_editor_path().resolve()),
+        return [str(self._unity_editor_path.resolve()),
                 "-projectpath",
-                str(self.project_path.resolve()),
+                str(self._project_path.resolve()),
                 "-quit",
                 "-batchmode"]
 


### PR DESCRIPTION
### `tdw` module

- Added optional parameter `unity_editor_path` to the `AssetBundleCreator`constructor to optionally explicitly set the path to the Unity Editor executable.
- Added: `AssetBundleCreator.cleanup()` Clean up intermediary files.
- Added optional parameter `unity_editor_path` to the `RobotCreator`constructor to optionally explicitly set the path to the Unity Editor executable.
- Changed the names of all undocumented fields in `AssetBundleCreator` and `RobotCreator` to private (added an `_` to the start of the variable names).
- Added optional parameters `description_infix` and `branch` to `RobotCreator.create_asset_bundles()` to handle unexpected .urdf URLs.

### Documentation

#### Modified Documentation

| Document                             | Modification                                                 |
| ------------------------------------ | ------------------------------------------------------------ |
| `lessons/3d_models/custom_models.md` | Added a section explaining how to manually set the Unity Editor path. |
| `lessons/robots/custom_robots.md`    | Added a section explaining how to manually set the Unity Editor path. |