### PR TITLE
Fixed fetch robot's wheels

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -34,9 +34,17 @@ To upgrade from TDW v1.8 to v1.9, read [this guide](upgrade_guides/v1.8_to_v1.9.
 
 - Added new composite object mechanism type: `prismatic_joint`
 
-### Model library
+### Model Library
 
 - Added to `models_core.json`: large_mesh_basket, trashbin, b04_11_02_041, b04_kevin_reilly_pattern_floor_lamp, duncan_floor_lamp_crate_and_barrel, b03_restoration_hardware_pedestal_salvaged_round_tables, b04_03_077, gas_stove
+
+### Robot Library
+
+- Fixed various issues with fetch robot's wheels:
+  - Added four revolute joints for the non-motorized wheels: non_motorized_wheel_front_left, non_motorized_wheel_front_right, non_motorized_wheel_back_left, non_motorized_wheel_back_right.
+  - Removed bellows_link_2 as a joint (it was causing fetch to turn and was otherwise non-functional) but kept the visual mesh.
+  - Removed estop_link as a joint (it didn't do anything) but kept the visual mesh.
+  - Removed laser_link fixed joint and visual mesh (it didn't do anything).
 
 ### Example Controllers
 

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from pathlib import Path
 import re
 
-__version__ = "1.9.2.2"
+__version__ = "1.9.2.3"
 readme_path = Path('../README.md')
 if readme_path.exists():
     long_description = readme_path.read_text(encoding='utf-8')

--- a/Python/tdw/metadata_libraries/robots.json
+++ b/Python/tdw/metadata_libraries/robots.json
@@ -1,242 +1,242 @@
 {
-  "description": "Robot asset bundles",
-  "records": {
-    "baxter": {
-      "ik": [],
-      "immovable": true,
-      "name": "baxter",
-      "source": "https://github.com/RethinkRobotics/baxter_common",
-      "targets": {},
-      "urls": {
-        "Darwin": "https://tdw-public.s3.amazonaws.com/robots/osx/2020.2/baxter",
-        "Linux": "https://tdw-public.s3.amazonaws.com/robots/linux/2020.2/baxter",
-        "Windows": "https://tdw-public.s3.amazonaws.com/robots/windows/2020.2/baxter"
-      }
-    },
-    "fetch": {
-      "ik": [],
-      "immovable": false,
-      "name": "fetch",
-      "source": "https://github.com/openai/roboschool",
-      "targets": {},
-      "urls": {
-        "Darwin": "https://tdw-public.s3.amazonaws.com/robots/osx/2020.2/fetch",
-        "Linux": "https://tdw-public.s3.amazonaws.com/robots/linux/2020.2/fetch",
-        "Windows": "https://tdw-public.s3.amazonaws.com/robots/windows/2020.2/fetch"
-      }
-    },
-    "niryo_one": {
-      "ik": [],
-      "immovable": true,
-      "name": "niryo_one",
-      "source": "https://github.com/NiryoRobotics/niryo_one_ros",
-      "targets": {},
-      "urls": {
-        "Darwin": "https://tdw-public.s3.amazonaws.com/robots/osx/2020.2/niryo_one",
-        "Linux": "https://tdw-public.s3.amazonaws.com/robots/linux/2020.2/niryo_one",
-        "Windows": "https://tdw-public.s3.amazonaws.com/robots/windows/2020.2/niryo_one"
-      }
-    },
-    "sawyer": {
-      "ik": [],
-      "immovable": true,
-      "name": "sawyer",
-      "source": "https://github.com/RethinkRobotics/sawyer_robot",
-      "targets": {},
-      "urls": {
-        "Darwin": "https://tdw-public.s3.amazonaws.com/robots/osx/2020.2/sawyer",
-        "Linux": "https://tdw-public.s3.amazonaws.com/robots/linux/2020.2/sawyer",
-        "Windows": "https://tdw-public.s3.amazonaws.com/robots/windows/2020.2/sawyer"
-      }
-    },
-    "shadowhand": {
-      "ik": [],
-      "immovable": true,
-      "name": "shadowhand",
-      "source": "https://github.com/shadow-robot/simox_ros",
-      "targets": {},
-      "urls": {
-        "Darwin": "https://tdw-public.s3.amazonaws.com/robots/osx/2020.2/shadowhand",
-        "Linux": "https://tdw-public.s3.amazonaws.com/robots/linux/2020.2/shadowhand",
-        "Windows": "https://tdw-public.s3.amazonaws.com/robots/windows/2020.2/shadowhand"
-      }
-    },
-    "ur10": {
-      "ik": [],
-      "immovable": true,
-      "name": "ur10",
-      "source": "https://github.com/ros-industrial/robot_movement_interface",
-      "targets": {
-        "upper_arm_link": {
-          "target": -5,
-          "type": "revolute"
+    "description": "Robot asset bundles",
+    "records": {
+        "baxter": {
+            "ik": [],
+            "immovable": true,
+            "name": "baxter",
+            "source": "https://github.com/RethinkRobotics/baxter_common",
+            "targets": {},
+            "urls": {
+                "Darwin": "https://tdw-public.s3.amazonaws.com/robots/osx/2020.2/baxter",
+                "Linux": "https://tdw-public.s3.amazonaws.com/robots/linux/2020.2/baxter",
+                "Windows": "https://tdw-public.s3.amazonaws.com/robots/windows/2020.2/baxter"
+            }
+        },
+        "fetch": {
+            "ik": [],
+            "immovable": false,
+            "name": "fetch",
+            "source": "https://github.com/openai/roboschool",
+            "targets": {},
+            "urls": {
+                "Darwin": "https://tdw-public.s3.amazonaws.com/robots/osx/2020.3.24f1/fetch",
+                "Linux": "https://tdw-public.s3.amazonaws.com/robots/linux/2020.3.24f1/fetch",
+                "Windows": "https://tdw-public.s3.amazonaws.com/robots/windows/2020.3.24f1/fetch"
+            }
+        },
+        "niryo_one": {
+            "ik": [],
+            "immovable": true,
+            "name": "niryo_one",
+            "source": "https://github.com/NiryoRobotics/niryo_one_ros",
+            "targets": {},
+            "urls": {
+                "Darwin": "https://tdw-public.s3.amazonaws.com/robots/osx/2020.2/niryo_one",
+                "Linux": "https://tdw-public.s3.amazonaws.com/robots/linux/2020.2/niryo_one",
+                "Windows": "https://tdw-public.s3.amazonaws.com/robots/windows/2020.2/niryo_one"
+            }
+        },
+        "sawyer": {
+            "ik": [],
+            "immovable": true,
+            "name": "sawyer",
+            "source": "https://github.com/RethinkRobotics/sawyer_robot",
+            "targets": {},
+            "urls": {
+                "Darwin": "https://tdw-public.s3.amazonaws.com/robots/osx/2020.2/sawyer",
+                "Linux": "https://tdw-public.s3.amazonaws.com/robots/linux/2020.2/sawyer",
+                "Windows": "https://tdw-public.s3.amazonaws.com/robots/windows/2020.2/sawyer"
+            }
+        },
+        "shadowhand": {
+            "ik": [],
+            "immovable": true,
+            "name": "shadowhand",
+            "source": "https://github.com/shadow-robot/simox_ros",
+            "targets": {},
+            "urls": {
+                "Darwin": "https://tdw-public.s3.amazonaws.com/robots/osx/2020.2/shadowhand",
+                "Linux": "https://tdw-public.s3.amazonaws.com/robots/linux/2020.2/shadowhand",
+                "Windows": "https://tdw-public.s3.amazonaws.com/robots/windows/2020.2/shadowhand"
+            }
+        },
+        "ur10": {
+            "ik": [],
+            "immovable": true,
+            "name": "ur10",
+            "source": "https://github.com/ros-industrial/robot_movement_interface",
+            "targets": {
+                "upper_arm_link": {
+                    "target": -5,
+                    "type": "revolute"
+                }
+            },
+            "urls": {
+                "Darwin": "https://tdw-public.s3.amazonaws.com/robots/osx/2020.2/ur10",
+                "Linux": "https://tdw-public.s3.amazonaws.com/robots/linux/2020.2/ur10",
+                "Windows": "https://tdw-public.s3.amazonaws.com/robots/windows/2020.2/ur10"
+            }
+        },
+        "ur3": {
+            "ik": [],
+            "immovable": true,
+            "name": "ur3",
+            "source": "https://github.com/Unity-Technologies/articulations-robot-demo",
+            "targets": {},
+            "urls": {
+                "Darwin": "https://tdw-public.s3.amazonaws.com/robots/osx/2020.2/ur3",
+                "Linux": "https://tdw-public.s3.amazonaws.com/robots/linux/2020.2/ur3",
+                "Windows": "https://tdw-public.s3.amazonaws.com/robots/windows/2020.2/ur3"
+            }
+        },
+        "ur5": {
+            "ik": [
+                [
+                    {
+                        "bounds": [
+                            -6.283185307179586,
+                            6.283185307179586
+                        ],
+                        "name": "shoulder_link",
+                        "orientation": [
+                            0,
+                            0,
+                            0
+                        ],
+                        "rotation": [
+                            0,
+                            -1,
+                            0
+                        ],
+                        "translation_vector": [
+                            0.0,
+                            0.08915899,
+                            0.0
+                        ]
+                    },
+                    {
+                        "bounds": [
+                            -6.283185307179586,
+                            6.283185307179586
+                        ],
+                        "name": "upper_arm_link",
+                        "orientation": [
+                            0,
+                            0,
+                            0
+                        ],
+                        "rotation": [
+                            1,
+                            0,
+                            0
+                        ],
+                        "translation_vector": [
+                            -0.13585,
+                            0.0,
+                            0.0
+                        ]
+                    },
+                    {
+                        "bounds": [
+                            -6.283185307179586,
+                            6.283185307179586
+                        ],
+                        "name": "forearm_link",
+                        "orientation": [
+                            0,
+                            0,
+                            0
+                        ],
+                        "rotation": [
+                            1,
+                            0,
+                            0
+                        ],
+                        "translation_vector": [
+                            0.1196999,
+                            0.0,
+                            0.425001
+                        ]
+                    },
+                    {
+                        "bounds": [
+                            -6.283185307179586,
+                            6.283185307179586
+                        ],
+                        "name": "wrist_1_link",
+                        "orientation": [
+                            0,
+                            0,
+                            0
+                        ],
+                        "rotation": [
+                            1,
+                            0,
+                            0
+                        ],
+                        "translation_vector": [
+                            0.0,
+                            0.0,
+                            0.3922516
+                        ]
+                    },
+                    {
+                        "bounds": [
+                            -6.283185307179586,
+                            6.283185307179586
+                        ],
+                        "name": "wrist_2_link",
+                        "orientation": [
+                            0,
+                            0,
+                            0
+                        ],
+                        "rotation": [
+                            0,
+                            -1,
+                            0
+                        ],
+                        "translation_vector": [
+                            -0.093,
+                            0.0,
+                            0.0
+                        ]
+                    },
+                    {
+                        "bounds": [
+                            null,
+                            null
+                        ],
+                        "name": "wrist_3_link",
+                        "orientation": [
+                            0,
+                            0,
+                            0
+                        ],
+                        "rotation": null,
+                        "translation_vector": [
+                            0.0,
+                            -0.09465025,
+                            0.0
+                        ]
+                    }
+                ]
+            ],
+            "immovable": true,
+            "name": "ur5",
+            "source": "https://github.com/ros-industrial/robot_movement_interface",
+            "targets": {
+                "upper_arm_link": {
+                    "target": -5,
+                    "type": "revolute"
+                }
+            },
+            "urls": {
+                "Darwin": "https://tdw-public.s3.amazonaws.com/robots/osx/2020.2/ur5",
+                "Linux": "https://tdw-public.s3.amazonaws.com/robots/linux/2020.2/ur5",
+                "Windows": "https://tdw-public.s3.amazonaws.com/robots/windows/2020.2/ur5"
+            }
         }
-      },
-      "urls": {
-        "Darwin": "https://tdw-public.s3.amazonaws.com/robots/osx/2020.2/ur10",
-        "Linux": "https://tdw-public.s3.amazonaws.com/robots/linux/2020.2/ur10",
-        "Windows": "https://tdw-public.s3.amazonaws.com/robots/windows/2020.2/ur10"
-      }
-    },
-    "ur3": {
-      "ik": [],
-      "immovable": true,
-      "name": "ur3",
-      "source": "https://github.com/Unity-Technologies/articulations-robot-demo",
-      "targets": {},
-      "urls": {
-        "Darwin": "https://tdw-public.s3.amazonaws.com/robots/osx/2020.2/ur3",
-        "Linux": "https://tdw-public.s3.amazonaws.com/robots/linux/2020.2/ur3",
-        "Windows": "https://tdw-public.s3.amazonaws.com/robots/windows/2020.2/ur3"
-      }
-    },
-    "ur5": {
-      "ik": [
-        [
-          {
-            "bounds": [
-              -6.283185307179586,
-              6.283185307179586
-            ],
-            "name": "shoulder_link",
-            "orientation": [
-              0,
-              0,
-              0
-            ],
-            "rotation": [
-              0,
-              -1,
-              0
-            ],
-            "translation_vector": [
-              0.0,
-              0.08915899,
-              0.0
-            ]
-          },
-          {
-            "bounds": [
-              -6.283185307179586,
-              6.283185307179586
-            ],
-            "name": "upper_arm_link",
-            "orientation": [
-              0,
-              0,
-              0
-            ],
-            "rotation": [
-              1,
-              0,
-              0
-            ],
-            "translation_vector": [
-              -0.13585,
-              0.0,
-              0.0
-            ]
-          },
-          {
-            "bounds": [
-              -6.283185307179586,
-              6.283185307179586
-            ],
-            "name": "forearm_link",
-            "orientation": [
-              0,
-              0,
-              0
-            ],
-            "rotation": [
-              1,
-              0,
-              0
-            ],
-            "translation_vector": [
-              0.1196999,
-              0.0,
-              0.425001
-            ]
-          },
-          {
-            "bounds": [
-              -6.283185307179586,
-              6.283185307179586
-            ],
-            "name": "wrist_1_link",
-            "orientation": [
-              0,
-              0,
-              0
-            ],
-            "rotation": [
-              1,
-              0,
-              0
-            ],
-            "translation_vector": [
-              0.0,
-              0.0,
-              0.3922516
-            ]
-          },
-          {
-            "bounds": [
-              -6.283185307179586,
-              6.283185307179586
-            ],
-            "name": "wrist_2_link",
-            "orientation": [
-              0,
-              0,
-              0
-            ],
-            "rotation": [
-              0,
-              -1,
-              0
-            ],
-            "translation_vector": [
-              -0.093,
-              0.0,
-              0.0
-            ]
-          },
-          {
-            "bounds": [
-              null,
-              null
-            ],
-            "name": "wrist_3_link",
-            "orientation": [
-              0,
-              0,
-              0
-            ],
-            "rotation": null,
-            "translation_vector": [
-              0.0,
-              -0.09465025,
-              0.0
-            ]
-          }
-        ]
-      ],
-      "immovable": true,
-      "name": "ur5",
-      "source": "https://github.com/ros-industrial/robot_movement_interface",
-      "targets": {
-        "upper_arm_link": {
-          "target": -5,
-          "type": "revolute"
-        }
-      },
-      "urls": {
-        "Darwin": "https://tdw-public.s3.amazonaws.com/robots/osx/2020.2/ur5",
-        "Linux": "https://tdw-public.s3.amazonaws.com/robots/linux/2020.2/ur5",
-        "Windows": "https://tdw-public.s3.amazonaws.com/robots/windows/2020.2/ur5"
-      }
     }
-  }
 }


### PR DESCRIPTION
Closes #341 

See: https://github.com/fetchrobotics/fetch_ros/issues/160


- Fixed various issues with fetch robot's wheels:
  - Added four revolute joints for the non-motorized wheels: non_motorized_wheel_front_left, non_motorized_wheel_front_right, non_motorized_wheel_back_left, non_motorized_wheel_back_right.
  - Removed bellows_link_2 as a joint (it was causing fetch to turn and was otherwise non-functional) but kept the visual mesh.
  - Removed estop_link as a joint (it didn't do anything) but kept the visual mesh.
  - Removed laser_link fixed joint and visual mesh (it didn't do anything).

To test, run this controller:

```python
from tdw.controller import Controller
from tdw.tdw_utils import TDWUtils
from tdw.add_ons.robot import Robot

c = Controller()

# Once this PR is merged to master, you should replace line 10 with:
# r = Robot(robot_id=0, name="fetch")
r = Robot(robot_id=0, name="fetch", source="https://tdw-public.s3.amazonaws.com/robots/linux/2020.3.24f1/fetch")

c.add_ons.append(r)
c.communicate(TDWUtils.create_empty_room(12, 12))
targets = {}
for wheel in ["r_wheel_link", "l_wheel_link"]:
    joint_id = r.static.joint_ids_by_name[wheel]
    targets[joint_id] = 2700
r.set_joint_targets(targets=targets)
joint_ids = list(targets.keys())
while r.joints_are_moving(joint_ids=joint_ids):
    c.communicate([])
for wheel_id in joint_ids:
    print(wheel_id, r.dynamic.joints[wheel_id].angles[0])
c.communicate({"$type": "terminate"})
```

Output:

```
-1360998261 2700.0376
1846548333 2699.984
```