### PR TITLE
Added: ThirdPersonCamera.look_at(target)

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -30,6 +30,7 @@ To upgrade from TDW v1.8 to v1.9, read [this guide](upgrade_guides/v1.8_to_v1.9.
 ### `tdw` module
 
 - Added: `OccupancyMap.reset()` Reset the occupancy map. Call this when resetting a scene.
+- Replaced `ThirdPersonCamera.look_at_target` with  `ThirdPersonCamera.look_at(target)` in order to allow the camera to look at a target on the next `communicate()` call.
 - Improved how cross-fading works in `PyImpact` between audio chunks during a scrape.
 
 ### Model library

--- a/Documentation/lessons/camera/rotation.md
+++ b/Documentation/lessons/camera/rotation.md
@@ -191,7 +191,7 @@ c.communicate([TDWUtils.create_empty_room(12, 12),
 c.communicate({"$type": "terminate"})
 ```
 
-The `ThirdPersonCamera` wraps both of these commands (`look_at` and `look_at_position` in a single field: `look_at_position`:
+The `ThirdPersonCamera` wraps both of these commands (`look_at` and `look_at_position` in a function: `camera.look_at(target)`. It will continue to look at the target every frame until you call `camera.look_at(None)`.
 
 ```python
 from tdw.controller import Controller
@@ -209,10 +209,10 @@ c.communicate([TDWUtils.create_empty_room(12, 12),
                                 position={"x": 1, "y": 0, "z": -0.5},
                                 object_id=object_id)])
 # Look at the object.
-cam.look_at_target = object_id
+cam.look_at(object_id)
 c.communicate([])
 # Look at a position.
-cam.look_at_target = {"x": -2, "y": 0.5, "z": 0}
+cam.look_at({"x": -2, "y": 0.5, "z": 0})
 c.communicate([])
 c.communicate({"$type": "terminate"})
 ```

--- a/Documentation/python/add_ons/third_person_camera.md
+++ b/Documentation/python/add_ons/third_person_camera.md
@@ -75,8 +75,6 @@ c.communicate(TDWUtils.create_empty_room(12, 12))
 
 - `position` The position of the camera. If None, defaults to `{"x": 0, "y": 0, "z": 0}`.
 
-- `look_at_target` The target object or position that the camera will look at. Can be None (the camera won't look at a target).
-
 - `follow_object` The ID of the object the camera will try to follow. Can be None (the camera won't follow an object).
 
 - `follow_rotate` If `follow_object` is not None, this determines whether the camera will follow the object's rotation.
@@ -144,6 +142,16 @@ Rotate the camera.
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | rotation |  Dict[str, float] |  | Rotate the camera by these angles (in degrees). Keys are `"x"`, `"y"`, `"z"` and correspond to `(pitch, yaw, roll)`. |
+
+#### look_at
+
+**`self.look_at(target)`**
+
+Look at a target position or object. The camera will continue to look at the target until you call `camera.look_at(None)`.
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| target |  Union[int, Dict[str, float] |  | The look at target. Can be an int (an object ID), an `(x, y, z)` dictionary (a position), or None (stop looking at a target). |
 
 #### before_send
 


### PR DESCRIPTION
### `tdw` module

- Replaced `ThirdPersonCamera.look_at_target` with  `ThirdPersonCamera.look_at(target)` in order to allow the camera to look at a target on the next `communicate()` call.