### PR TITLE
Fixed: fmedia doesn't work on OS X

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -32,6 +32,7 @@ To upgrade from TDW v1.8 to v1.9, read [this guide](upgrade_guides/v1.8_to_v1.9.
 - Added: `OccupancyMap.reset()` Reset the occupancy map. Call this when resetting a scene.
 - Replaced `ThirdPersonCamera.look_at_target` with  `ThirdPersonCamera.look_at(target)` in order to allow the camera to look at a target on the next `communicate()` call.
 - Improved how cross-fading works in `PyImpact` between audio chunks during a scrape.
+- Fixed: `AudioUtils` (and, by extension, `PhysicsAudioRecorder`) doesn't work on OS X.
 
 ### Model library
 
@@ -54,10 +55,12 @@ To upgrade from TDW v1.8 to v1.9, read [this guide](upgrade_guides/v1.8_to_v1.9.
 
 #### Modified Documentation
 
-| Document                               | Modification                                                 |
-| -------------------------------------- | ------------------------------------------------------------ |
-| `lessons/physx/composite_objects.md`   | Clarified how to use various means to set kinematic states of sub-objects. |
-| `lessons/navigation/occupancy_maps.md` | Added a section for resetting a scene.                       |
+| Document                                                   | Modification                                                 |
+| ---------------------------------------------------------- | ------------------------------------------------------------ |
+| `lessons/physx/composite_objects.md`                       | Clarified how to use various means to set kinematic states of sub-objects. |
+| `lessons/navigation/occupancy_maps.md`                     | Added a section for resetting a scene.                       |
+| `lessons/objects_and_scenes/materials_textures_colords.md` | Added a missing line of code in one of the examples.         |
+| `lessons/audio/recording_audio.md`                         | Added instructions for installing fmedia on all platforms (including OS X) |
 
 ## v1.9.2
 

--- a/Documentation/lessons/audio/record_audio.md
+++ b/Documentation/lessons/audio/record_audio.md
@@ -12,7 +12,7 @@
 
 - The controller and build must be on the same computer.
 
-- [fmedia](https://stsaz.github.io/fmedia/) The install instructions are listed on the fmedia homepage and vary between operating systems.
+- [fmedia](https://stsaz.github.io/fmedia/) See below for how to install.
 
 - Your audio drivers must be set up to allow for recording off of the system. One of the audio devices on your computer must be "Stereo Mix". If not, you need to upgrade or replace your audio drivers; how to do this will vary greatly by operating system and hardware. To check if you have the correct audio device, run this program; if it raises an exception, you don't have a "Stereo Mix" audio device:
 
@@ -20,6 +20,29 @@
   from tdw.audio_utils import AudioUtils
   AudioUtils.get_system_audio_device()
   ```
+
+### Install fmedia
+
+#### Windows
+
+1. [Download fmedia.](https://stsaz.github.io/fmedia/)
+2. Unpack archive to the directory of your choice.
+3. Run the following command from console (cmd.exe): `"C:\Program Files\fmedia\fmedia.exe" --install`
+
+#### OS X
+
+1. [Download fmedia.](https://stsaz.github.io/fmedia/)
+2. Unpack archive to the directory of your choice.
+3. [Add the location of the fmedia directory to the $PATH variable.](https://www.architectryan.com/2012/10/02/add-to-the-path-on-mac-os-x-mountain-lion/)
+4. Download [iShowU Audio Capture](https://support.shinywhitebox.com/hc/en-us/articles/204161459-Installing-iShowU-Audio-Capture-Mojave-and-earlier-).
+5. Go to “Audio MIDI Setup” on your Mac and create a new device with multiple output channels that should include the “iShowU Audio Capture” and the usual device that you use for audio output in your computer.
+
+#### Linux
+
+1. [Download fmedia](https://stsaz.github.io/fmedia/)
+2. Unpack archive to the directory of your choice:  `tar Jxf ./fmedia-1.0-linux-amd64.tar.xz -C /usr/local`  
+3. Create a symbolic link: `ln -s /usr/local/fmedia-1/fmedia /usr/local/bin/fmedia`
+
 
 ## Record audio with `AudioUtils`
 

--- a/Documentation/lessons/audio/record_audio.md
+++ b/Documentation/lessons/audio/record_audio.md
@@ -9,17 +9,18 @@
 ## Requirements
 
 - [See audio playback requirements.](initialize_audio.md)
-
 - The controller and build must be on the same computer.
-
 - [fmedia](https://stsaz.github.io/fmedia/) See below for how to install.
-
-- Your audio drivers must be set up to allow for recording off of the system. One of the audio devices on your computer must be "Stereo Mix". If not, you need to upgrade or replace your audio drivers; how to do this will vary greatly by operating system and hardware. To check if you have the correct audio device, run this program; if it raises an exception, you don't have a "Stereo Mix" audio device:
-
+- Your audio drivers must be set up to allow for recording off of the system. To check if you have the correct audio device, run this program; if it raises an exception, you don't have an appropriate audio device:
+  
   ```python
   from tdw.audio_utils import AudioUtils
   AudioUtils.get_system_audio_device()
   ```
+  
+    - *Windows and Linux:* The correct audio device is "Stereo Mix"; if your computer doesn't have this audio device,  upgrade or replace your audio drivers; how to do this will vary greatly by operating system and hardware.
+  
+    - *OS X:* The correct audio device is "iShowU Audio Capture"; see below for how to install it. 
 
 ### Install fmedia
 

--- a/Documentation/lessons/objects_and_scenes/materials_textures_colors.md
+++ b/Documentation/lessons/objects_and_scenes/materials_textures_colors.md
@@ -206,6 +206,7 @@ c = Controller()
 object_id = c.get_unique_id()
 
 model_record = ModelLibrarian().get_record("white_lounger_chair")
+material_name = "parquet_long_horizontal_clean"
 cam = ThirdPersonCamera(position={"x": 2, "y": 1.6, "z": -0.6},
                         look_at=object_id)
 path = EXAMPLE_CONTROLLER_OUTPUT_PATH.joinpath("set_visual_material")

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from pathlib import Path
 import re
 
-__version__ = "1.9.3.1"
+__version__ = "1.9.3.2"
 readme_path = Path('../README.md')
 if readme_path.exists():
     long_description = readme_path.read_text(encoding='utf-8')

--- a/Python/tdw/audio_utils.py
+++ b/Python/tdw/audio_utils.py
@@ -1,6 +1,7 @@
 from typing import Optional, Union, Tuple
 from pathlib import Path
 import os
+from platform import system
 from subprocess import check_output, Popen, call
 import re
 from psutil import pid_exists
@@ -42,7 +43,10 @@ class AudioUtils:
         """
 
         devices = check_output(["fmedia", "--list-dev"]).decode("utf-8").split("Capture:")[1]
-        dev_search = re.search("device #(.*): Stereo Mix", devices, flags=re.MULTILINE)
+        if system() == "Darwin":
+            dev_search = re.search("device #(.*): iShowU Audio Capture", devices, flags=re.MULTILINE)
+        else:
+            dev_search = re.search("device #(.*): Stereo Mix", devices, flags=re.MULTILINE)
         assert dev_search is not None, "No suitable audio capture device found:\n" + devices
         return dev_search.group(1)
 


### PR DESCRIPTION
### `tdw` module

 - Fixed: `AudioUtils` (and, by extension, `PhysicsAudioRecorder`) doesn't work on OS X.

### Documentation


#### Modified Documentation

| Document                               | Modification                                                 |
| -------------------------------------- | ------------------------------------------------------------ |
| `lessons/objects_and_scenes/materials_textures_colords.md` | Added a missing line of code in one of the examples.         |
| `lessons/audio/recording_audio.md`                         | Added instructions for installing fmedia on all platforms (including OS X) |