### PR TITLE
Added motor commands

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -15,12 +15,15 @@ To upgrade from TDW v1.8 to v1.9, read [this guide](upgrade_guides/v1.8_to_v1.9.
 | `set_spring_target_position` | Set the target position of a spring. |
 | `set_spring_damper`          | Set the damper value of a spring.    |
 | `set_spring_force`           | Set the force of a spring.           |
+| `set_motor_target_velocity`  | Set the target velocity of a motor.  |
+| `set_motor_force`            | Set the force of a motor.            |
 
 #### Removed Commands
 
-| Command      | Reason                                     |
-| ------------ | ------------------------------------------ |
-| `set_spring` | Replaced with `set_spring_target_position` |
+| Command      | Reason                                                       |
+| ------------ | ------------------------------------------------------------ |
+| `set_spring` | Replaced with `set_spring_target_position`                   |
+| `set_motor`  | Replaced with `set_motor_target_velocity` and `set_motor_force` |
 
 ## v1.9.3
 

--- a/Documentation/api/command_api.md
+++ b/Documentation/api/command_api.md
@@ -363,7 +363,8 @@
 | Command | Description |
 | --- | --- |
 | [`set_hinge_limits`](#set_hinge_limits) | Set the angle limits of a hinge joint. This will work with hinges, motors, and springs.  |
-| [`set_motor`](#set_motor) | Set the target velocity and force of a motor.  |
+| [`set_motor_force`](#set_motor_force) | Set the force a motor.  |
+| [`set_motor_target_velocity`](#set_motor_target_velocity) | Set the target velocity a motor.  |
 | [`set_spring_damper`](#set_spring_damper) | Set the damper value of a spring.  |
 | [`set_spring_force`](#set_spring_force) | Set the force of a spring.  |
 | [`set_spring_target_position`](#set_spring_target_position) | Set the target position of a spring.  |
@@ -4882,22 +4883,40 @@ Set the angle limits of a hinge joint. This will work with hinges, motors, and s
 
 ***
 
-## **`set_motor`**
+## **`set_motor_force`**
 
-Set the target velocity and force of a motor. 
+Set the force a motor. 
 
 - <font style="color:deepskyblue">**Sub-Object**: This command will only work with a sub-object of a Composite Object. The sub-object must be of the correct type. To determine which Composite Objects are currently in the scene, and the types of their sub-objects, send the [send_composite_objects](#send_composite_objects) command.</font>
 
     - <font style="color:deepskyblue">**Type:** `motor`</font>
 
 ```python
-{"$type": "set_motor", "target_velocity": 0.125, "force": 0.125, "id": 1}
+{"$type": "set_motor_force", "force": 0.125, "id": 1}
+```
+
+| Parameter | Type | Description | Default |
+| --- | --- | --- | --- |
+| `"force"` | float | The force of the motor. | |
+| `"id"` | int | The unique object ID. | |
+
+***
+
+## **`set_motor_target_velocity`**
+
+Set the target velocity a motor. 
+
+- <font style="color:deepskyblue">**Sub-Object**: This command will only work with a sub-object of a Composite Object. The sub-object must be of the correct type. To determine which Composite Objects are currently in the scene, and the types of their sub-objects, send the [send_composite_objects](#send_composite_objects) command.</font>
+
+    - <font style="color:deepskyblue">**Type:** `motor`</font>
+
+```python
+{"$type": "set_motor_target_velocity", "target_velocity": 0.125, "id": 1}
 ```
 
 | Parameter | Type | Description | Default |
 | --- | --- | --- | --- |
 | `"target_velocity"` | float | The target velocity of the motor. | |
-| `"force"` | float | The force of the motor. | |
 | `"id"` | int | The unique object ID. | |
 
 ***

--- a/Documentation/lessons/physx/composite_objects.md
+++ b/Documentation/lessons/physx/composite_objects.md
@@ -62,7 +62,7 @@ The "sub-object machine type" determines which API command can be used for this 
 | Machine type        | Behavior                                                     | Example                | Command(s)                                                   |
 | ------------------- | ------------------------------------------------------------ | ---------------------- | ------------------------------------------------------------ |
 | `"light"`           | Can be turned on and off.                                    | A lightbulb            | [`set_sub_object_light`](../../api/command_api.md#set_sub_object_light) |
-| `"motor"`           | Can rotate on a pivot point around an axis by applying a target velocity and a force magnitude. | A helicopter propeller | [`set_motor`](../../api/command_api.md#set_motor)<br>[`set_hinge_limits`](../../api/command_api.md#set_hinge_limits) |
+| `"motor"`           | Can rotate on a pivot point around an axis by applying a target velocity and a force magnitude. | A helicopter propeller | [`set_motor_force`](../../api/command_api.md#set_motor_force)<br>[`set_motor_target_velocity`](../../api/command_api.md#set_motor_target_velocity)<br/>[`set_hinge_limits`](../../api/command_api.md#set_hinge_limits) |
 | `"hinge"`           | Swings freely on a pivot point around an axis.               | A box with a lid       | [`set_hinge_limits`](../../api/command_api.md#set_hinge_limits) |
 | `"spring"`          | Can rotate on a pivot point around an axis by applying a target position. The motion will appear "spring-like". | An oven door           | [`set_spring_target_position`](../../api/command_api.md#set_spring_target_position)<br>[`set_spring_damper`](../../api/command_api.md#set_spring_damper)<br>[`set_spring_force`](../../api/command_api.md#set_spring_force)<br>[`set_hinge_limits`](../../api/command_api.md#set_hinge_limits) |
 | `"prismatic_joint"` | Can move linearly along an axis                              | A chest of drawers     |                                                              |
@@ -157,7 +157,8 @@ Python API:
 Command API:
 
 - [`set_sub_object_light`](../../api/command_api.md#set_sub_object_light)
-- [`set_motor`](../../api/command_api.md#set_motor)
+- [`set_motor_force`](../../api/command_api.md#set_motor_force)
+- [`set_motor_target_velocity`](../../api/command_api.md#set_motor_target_velocity)
 - [`set_spring_target_position`](../../api/command_api.md#set_spring_target_position)
 - [`set_spring_damper`](../../api/command_api.md#set_spring_damper)
 - [`set_spring_force`](../../api/command_api.md#set_spring_force) 


### PR DESCRIPTION
### Command API

#### New Commands

| Command                      | Description                          |
| ---------------------------- | ------------------------------------ |
| `set_motor_target_velocity`  | Set the target velocity of a motor.  |
| `set_motor_force`            | Set the force of a motor.            |

#### Removed Commands

| Command      | Reason                                                       |
| ------------ | ------------------------------------------------------------ |
| `set_motor`  | Replaced with `set_motor_target_velocity` and `set_motor_force` |