### PR TITLE
Oculus Touch add-on auto-sets Discrete collision detection mode

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -65,6 +65,7 @@ To upgrade from TDW v1.8 to v1.9, read [this guide](upgrade_guides/v1.8_to_v1.9.
     - `CollisionMaterial`
     - `MaterialCombineMode`
 - Fixed: `AssetBundleCreator` fails because the `asset_bundle_creator/` Unity project doesn't include Newtonsoft.JSON
+- By default, the `OculusTouch` add-on will set the rig's hands and all graspable objects to the "discrete" collision detection mode.
 
 ### Model Library
 
@@ -85,10 +86,11 @@ To upgrade from TDW v1.8 to v1.9, read [this guide](upgrade_guides/v1.8_to_v1.9.
 
 #### Modified Documentation
 
-| Document                           | Modification                               |
-| ---------------------------------- | ------------------------------------------ |
-| `lessons/flex/fluid_and_source.md` | Added deprecation notice.                  |
-| `lessons/physx/overview.md`        | Updated comparison section to include Obi. |
+| Document                           | Modification                                   |
+| ---------------------------------- | ---------------------------------------------- |
+| `lessons/flex/fluid_and_source.md` | Added deprecation notice.                      |
+| `lessons/physx/overview.md`        | Updated comparison section to include Obi.     |
+| `lessons/vr/oculus_touch.md`       | Added a section regarding physics glitchiness. |
 
 ### Benchmarking
 

--- a/Documentation/lessons/vr/oculus_touch.md
+++ b/Documentation/lessons/vr/oculus_touch.md
@@ -481,6 +481,16 @@ if __name__ == "__main__":
     c.run()
 ```
 
+## Physics glitches
+
+There are known physics glitches associated with the Oculus Touch rig, particularly when grasping objects, the most common being that objects will interpenetrate. There are several overlapping causes for this:
+
+ By default, all objects in TDW use [the `continuous_dynamic` collision detection mode](../../command_api.md#set_object_collision_detection_mode). VR simulations seem to work better when non-kinematic objects use the `discrete` collision detection mode (emphasis on "seem" because there isn't an automated means of testing this behavior). By default, the `OculusTouch` add-on will set the hands of the rig and all graspable objects to `discrete`. There are cases where this won't be desirable because the physics behavior will be different in a VR scene than in a non-VR scene. You can optionally set `discrete_collision_detection=False` in the `OculusTouch` constructor.
+
+Some of the glitchiness is possibly due to how the rig's hands work (they use third-party code), but we haven't yet fully explored to what extent this is true or what can be done to fix it.
+
+Some of the glitchiness is probably due to issues in the PhysX engine itself. In general, models with simpler geometry seem to work better in VR.
+
 ## Low-level commands
 
 The `OculusTouchRig` initializes the rig with the following commands:

--- a/Documentation/python/add_ons/oculus_touch.md
+++ b/Documentation/python/add_ons/oculus_touch.md
@@ -42,7 +42,7 @@ Per-frame, update the positions of the VR rig, its hands, and its head, as well 
 
 **`OculusTouch()`**
 
-**`OculusTouch(human_hands=True, set_graspable=True, output_data=True, attach_avatar=False, avatar_camera_width=512, headset_aspect_ratio=0.9, headset_resolution_scale=1.0, non_graspable=None)`**
+**`OculusTouch(human_hands=True, set_graspable=True, output_data=True, attach_avatar=False, avatar_camera_width=512, headset_aspect_ratio=0.9, headset_resolution_scale=1.0, non_graspable=None, discrete_collision_detection_mode=True)`**
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -54,6 +54,7 @@ Per-frame, update the positions of the VR rig, its hands, and its head, as well 
 | headset_aspect_ratio |  float  | 0.9 | The `width / height` aspect ratio of the VR headset. This is only relevant if `attach_avatar` is `True` because it is used to set the height of the output images. The default value is the correct value for all Oculus devices. |
 | headset_resolution_scale |  float  | 1.0 | The headset resolution scale controls the actual size of eye textures as a multiplier of the device's default resolution. A value greater than 1 improves image quality but at a slight performance cost. Range: 0.5 to 1.75 |
 | non_graspable |  List[int] | None | A list of IDs of non-graspable objects. By default, all non-kinematic objects are graspable and all kinematic objects are non-graspable. Set this to make non-kinematic objects non-graspable. |
+| discrete_collision_detection_mode |  bool  | True | If True, the VR rig's hands and all graspable objects in the scene will be set to the `"discrete"` collision detection mode, which seems to reduce physics glitches in VR. If False, the VR rig's hands and all graspable objects will be set to the `"continuous_dynamic"` collision detection mode (the default in TDW). |
 
 #### get_initialization_commands
 

--- a/Python/tdw/add_ons/oculus_touch.py
+++ b/Python/tdw/add_ons/oculus_touch.py
@@ -16,7 +16,8 @@ class OculusTouch(VR):
 
     def __init__(self, human_hands: bool = True, set_graspable: bool = True, output_data: bool = True,
                  attach_avatar: bool = False, avatar_camera_width: int = 512, headset_aspect_ratio: float = 0.9,
-                 headset_resolution_scale: float = 1.0, non_graspable: List[int] = None):
+                 headset_resolution_scale: float = 1.0, non_graspable: List[int] = None,
+                 discrete_collision_detection_mode: bool = True):
         """
         :param human_hands: If True, visualize the hands as human hands. If False, visualize the hands as robot hands.
         :param set_graspable: If True, set all [non-kinematic objects](../../lessons/physx/physics_objects.md) and [composite sub-objects](../../lessons/semantic_states/composite_objects.md) as graspable by the VR rig.
@@ -26,6 +27,7 @@ class OculusTouch(VR):
         :param headset_aspect_ratio: The `width / height` aspect ratio of the VR headset. This is only relevant if `attach_avatar` is `True` because it is used to set the height of the output images. The default value is the correct value for all Oculus devices.
         :param headset_resolution_scale: The headset resolution scale controls the actual size of eye textures as a multiplier of the device's default resolution. A value greater than 1 improves image quality but at a slight performance cost. Range: 0.5 to 1.75
         :param non_graspable: A list of IDs of non-graspable objects. By default, all non-kinematic objects are graspable and all kinematic objects are non-graspable. Set this to make non-kinematic objects non-graspable.
+        :param discrete_collision_detection_mode: If True, the VR rig's hands and all graspable objects in the scene will be set to the `"discrete"` collision detection mode, which seems to reduce physics glitches in VR. If False, the VR rig's hands and all graspable objects will be set to the `"continuous_dynamic"` collision detection mode (the default in TDW).
         """
 
         if human_hands:
@@ -44,6 +46,7 @@ class OculusTouch(VR):
             self._non_graspable: List[int] = list()
         else:
             self._non_graspable: List[int] = non_graspable
+        self._discrete_collision_detection_mode: bool = discrete_collision_detection_mode
 
     def get_initialization_commands(self) -> List[dict]:
         commands = super().get_initialization_commands()
@@ -68,6 +71,14 @@ class OculusTouch(VR):
                     vr_node_ids = [static_oculus_touch.get_body_id(),
                                    static_oculus_touch.get_left_hand_id(),
                                    static_oculus_touch.get_right_hand_id()]
+                    # Set the collision detection modes of the rig's hands.
+                    if self._discrete_collision_detection_mode:
+                        self.commands.extend([{"$type": "set_object_collision_detection_mode",
+                                               "id": vr_node_ids[1],
+                                               "mode": "discrete"},
+                                              {"$type": "set_object_collision_detection_mode",
+                                               "id": vr_node_ids[2],
+                                               "mode": "discrete"}])
                     break
             for i in range(len(resp) - 1):
                 r_id = OutputData.get_data_type_id(resp[i])
@@ -75,10 +86,16 @@ class OculusTouch(VR):
                     static_rigidbodies = StaticRigidbodies(resp[i])
                     for j in range(static_rigidbodies.get_num()):
                         object_id = static_rigidbodies.get_id(j)
+                        # Make all non-kinematic objects graspable unless they are in `self._non_graspable`.
                         if object_id not in vr_node_ids and not static_rigidbodies.get_kinematic(j) and \
                                 object_id not in self._non_graspable:
                             self.commands.append({"$type": "set_vr_graspable",
                                                   "id": object_id})
+                            # Set "discrete" collision detection mode for each graspable object.
+                            if self._discrete_collision_detection_mode:
+                                self.commands.append({"$type": "set_object_collision_detection_mode",
+                                                      "id": object_id,
+                                                      "mode": "discrete"})
                     break
         super().on_send(resp=resp)
         # Get the button presses.


### PR DESCRIPTION
- By default, the `OculusTouch` add-on will set the rig's hands and all graspable objects to the "discrete" collision detection mode.
- Updated the Oculus Touch doc with a section re: physics glitches