### PR TITLE
Added commands to parent and unparent textured quads

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -6,9 +6,26 @@ To upgrade from TDW v1.8 to v1.9, read [this guide](upgrade_guides/v1.8_to_v1.9.
 
 ## v1.9.15
 
+### Command API
+
+#### New Commands
+
+| Command                          | Description                                                  |
+| -------------------------------- | ------------------------------------------------------------ |
+| `parent_textured_quad_to_object` | Parent a textured quad to an object in the scene. The textured quad will always be at a fixed local position and rotation relative to the object. |
+| `unparent_textured_quad`         | Unparent a textured quad from an object.                     |
+
 ### Build
 
 - Fixed: `add_ui_image` often creates images with badly-stretched borders.
+
+### Documentation
+
+#### Modified Documentation
+
+| Document                                | Modification                                                 |
+| --------------------------------------- | ------------------------------------------------------------ |
+| `lessons/non_physics/textured_quads.md` | Clarified  that only textured quad commands work with textured quads. |
 
 ## v1.9.14
 

--- a/Documentation/api/command_api.md
+++ b/Documentation/api/command_api.md
@@ -337,7 +337,7 @@
 | [`set_physic_material`](#set_physic_material) | Set the physic material of an object and apply friction and bounciness values to the object. These settings can be overriden by sending the command again, or by assigning a semantic material via set_semantic_material_to. |
 | [`set_vr_graspable`](#set_vr_graspable) | Make an object graspable for a VR rig, with Oculus touch controllers. Uses the AutoHand plugin for grasping and physics interaction behavior.  |
 | [`teleport_object`](#teleport_object) | Teleport an object to a new position. |
-| [`unparent_object`](#unparent_object) | Unparent an object from its current parent (an avatar, an avatar's camera, etc.). If the object doesn't have a parent, this command doesn't do anything. |
+| [`unparent_object`](#unparent_object) | Unparent an object from an object. If the textured quad doesn't have a parent, this command doesn't do anything. |
 
 **Flex Object Command**
 
@@ -643,12 +643,14 @@
 
 | Command | Description |
 | --- | --- |
+| [`parent_textured_quad_to_object`](#parent_textured_quad_to_object) | Parent a textured quad to an object in the scene. The textured quad will always be at a fixed local position and rotation relative to the object. |
 | [`rotate_textured_quad_by`](#rotate_textured_quad_by) | Rotate a textured quad by a given angle around a given axis. |
 | [`rotate_textured_quad_to`](#rotate_textured_quad_to) | Set the rotation of a textured quad. |
 | [`scale_textured_quad`](#scale_textured_quad) | Scale a textured quad by a factor. |
 | [`set_textured_quad`](#set_textured_quad) | Apply a texture to a pre-existing quad.  |
 | [`show_textured_quad`](#show_textured_quad) | Show or hide a textured quad. |
 | [`teleport_textured_quad`](#teleport_textured_quad) | Teleport a textured quad to a new position. |
+| [`unparent_textured_quad`](#unparent_textured_quad) | Unparent a textured quad from a parent object. If the textured quad doesn't have a parent object, this command doesn't do anything. |
 
 **Ui Command**
 
@@ -4650,7 +4652,7 @@ Teleport an object to a new position.
 
 ## **`unparent_object`**
 
-Unparent an object from its current parent (an avatar, an avatar's camera, etc.). If the object doesn't have a parent, this command doesn't do anything.
+Unparent an object from an object. If the textured quad doesn't have a parent, this command doesn't do anything.
 
 
 ```python
@@ -8410,6 +8412,22 @@ These commands adjust an existing textured quad.
 
 ***
 
+## **`parent_textured_quad_to_object`**
+
+Parent a textured quad to an object in the scene. The textured quad will always be at a fixed local position and rotation relative to the object.
+
+
+```python
+{"$type": "parent_textured_quad_to_object", "object_id": 1, "id": 1}
+```
+
+| Parameter | Type | Description | Default |
+| --- | --- | --- | --- |
+| `"object_id"` | int | The ID of the parent object in the scene. | |
+| `"id"` | int | The unique ID of this textured quad. | |
+
+***
+
 ## **`rotate_textured_quad_by`**
 
 Rotate a textured quad by a given angle around a given axis.
@@ -8528,6 +8546,21 @@ Teleport a textured quad to a new position.
 | Parameter | Type | Description | Default |
 | --- | --- | --- | --- |
 | `"position"` | Vector3 | New position of the quad. | |
+| `"id"` | int | The unique ID of this textured quad. | |
+
+***
+
+## **`unparent_textured_quad`**
+
+Unparent a textured quad from a parent object. If the textured quad doesn't have a parent object, this command doesn't do anything.
+
+
+```python
+{"$type": "unparent_textured_quad", "id": 1}
+```
+
+| Parameter | Type | Description | Default |
+| --- | --- | --- | --- |
 | `"id"` | int | The unique ID of this textured quad. | |
 
 # UiCommand

--- a/Documentation/lessons/non_physics/overview.md
+++ b/Documentation/lessons/non_physics/overview.md
@@ -6,12 +6,6 @@ There are various types of objects in TDW that are *non-physics objects*, meanin
 
 Non-physics objects have been added into TDW in a relatively piecemeal fashion. Some are are technically [objects](../core_concepts/objects.md) in the TDW sense, meaning that they will respond to non-physics object commands. For example, `teleport_object` will work with [non-physics humanoids](humanoids.md) but `set_mass` will not. Other non-physics objects use entirely different backend code. For example, [position markers](position_markers.md) are *not* objects in the TDW sense and will only respond to position marker commands. 
 
-This tutorial will cover the three types of non-physics objects currently in TDW:
-
-- [Position markers](position_markers.md) Simple shapes that can be used for debugging
-- [Textured quads](textured_quads.md) Simple rectangular meshes that can display a given image
-- [Non-physics humanoids](humanoids.md) Humanoids without mass, colliders, etc.
-
 ***
 
 **Next: [Position markers](position_markers.md)**

--- a/Documentation/lessons/non_physics/textured_quads.md
+++ b/Documentation/lessons/non_physics/textured_quads.md
@@ -98,12 +98,14 @@ Result:
 | [`show_textured_quad`](../../api/command_api.md#show_textured_quad) | Show or hide a textured quad.                                |
 | [`teleport_textured_quad`](../../api/command_api.md#teleport_textured_quad) | Set the position of a textured quad.                         |
 | [`rotate_textured_quad_to`](../../api/command_api.md#rotate_textured_quad_to) | Set the rotation of a textured quad.                         |
+| [`parent_textured_quad_to_object`](../../api/command_api.md#parent_textured_quad_to_object) | Parent a textured quad to an object in the scene. The textured quad will always be at a fixed local position and rotation relative to the object. |
+| [`unparent_textured_quad`](../../api/command_api.md#unparent_textured_quad) | Unparent a textured quad from an object.                     |
 
 ## Command API and output data
 
-In the Unity Engine, textured quads are effectively the same thing as any other non-physics object: They are a game object with a simple mesh (a "quad") and a material, which has an albedo image texture. 
+Textured quad commands aren't [TDW objects](../core_concepts/objects.md). None of the object commands such as `teleport_object` or `rotate_object_by` will work with textured quads. Only the textured quad commands, listed above, will work with textured quads.
 
-However, in TDW, textured quads are treated very differently than standard [objects](../core_concepts/objects.md). They won't appear in *any* output data except `Images` (and only in the `_img` pass).
+Likewise, textured quads won't appear in any output data except in the `_img` pass of `Images`.
 
 ***
 
@@ -127,3 +129,5 @@ Command API:
 - [`show_textured_quad`](../../api/command_api.md#show_textured_quad)
 - [`teleport_textured_quad`](../../api/command_api.md#teleport_textured_quad)
 - [`rotate_textured_quad_to`](../../api/command_api.md#rotate_textured_quad_to)
+- [`parent_textured_quad_to_object`](../../api/command_api.md#parent_textured_quad_to_object)
+- [`unparent_textured_quad`](../../api/command_api.md#unparent_textured_quad)


### PR DESCRIPTION
### Command API

#### New Commands

| Command                          | Description                                                  |
| -------------------------------- | ------------------------------------------------------------ |
| `parent_textured_quad_to_object` | Parent a textured quad to an object in the scene. The textured quad will always be at a fixed local position and rotation relative to the object. |
| `unparent_textured_quad`         | Unparent a textured quad from an object.                     |

### Documentation

#### Modified Documentation

| Document                                | Modification                                                 |
| --------------------------------------- | ------------------------------------------------------------ |
| `lessons/non_physics/textured_quads.md` | Clarified  that only textured quad commands work with textured quads. |