### PR TITLE
Set default VR rig UI canvas plane distance to 0.25

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -21,6 +21,8 @@ To upgrade from TDW v1.8 to v1.9, read [this guide](upgrade_guides/v1.8_to_v1.9.
 ### `tdw` module
 
 - Added field `impulse` to `CollisionObjObj`
+- Added optional field `plane_distance` to `ui.attach_canvas_to_avatar()` and `ui.attach_canvas_to_vr_rig()`. 
+- The default `plane_distance` value for `ui.attach_canvas_to_vr_rig(plane_distance)` is 0.25 (was 1)
 
 ### Model Library
 

--- a/Documentation/python/add_ons/ui.md
+++ b/Documentation/python/add_ons/ui.md
@@ -133,7 +133,7 @@ Set the size of a UI element that is already in the scene.
 
 **`self.attach_canvas_to_avatar()`**
 
-**`self.attach_canvas_to_avatar(avatar_id="a", focus_distance=2.5)`**
+**`self.attach_canvas_to_avatar(avatar_id="a", focus_distance=2.5, plane_distance=0.101)`**
 
 Attach the UI canvas to an avatar. This allows the UI to appear in image output data.
 
@@ -141,12 +141,19 @@ Attach the UI canvas to an avatar. This allows the UI to appear in image output 
 | --- | --- | --- | --- |
 | avatar_id |  str  | "a" | The avatar ID. |
 | focus_distance |  float  | 2.5 | The focus distance. If the focus distance is less than the default value (2.5), the UI will appear blurry unless post-processing is disabled. |
+| plane_distance |  float  | 0.101 | The distance from the camera to the UI canvas. This should be slightly further than the near clipping plane. |
 
 #### attach_canvas_to_vr_rig
 
 **`self.attach_canvas_to_vr_rig()`**
 
+**`self.attach_canvas_to_vr_rig(plane_distance=0.25)`**
+
 Attach the UI canvas to a VR rig.
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| plane_distance |  float  | 0.25 | The distance from the camera to the UI canvas. |
 
 #### destroy
 

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from pathlib import Path
 import re
 
-__version__ = "1.9.16.2"
+__version__ = "1.9.16.3"
 readme_path = Path('../README.md')
 if readme_path.exists():
     long_description = readme_path.read_text(encoding='utf-8')

--- a/Python/tdw/add_ons/ui.py
+++ b/Python/tdw/add_ons/ui.py
@@ -119,27 +119,31 @@ class UI(AddOn):
                               "canvas_id": self._canvas_id,
                               "size": size})
 
-    def attach_canvas_to_avatar(self, avatar_id: str = "a", focus_distance: float = 2.5) -> None:
+    def attach_canvas_to_avatar(self, avatar_id: str = "a", focus_distance: float = 2.5, plane_distance: float = 0.101) -> None:
         """
         Attach the UI canvas to an avatar. This allows the UI to appear in image output data.
 
         :param avatar_id: The avatar ID.
         :param focus_distance: The focus distance. If the focus distance is less than the default value (2.5), the UI will appear blurry unless post-processing is disabled.
+        :param plane_distance: The distance from the camera to the UI canvas. This should be slightly further than the near clipping plane.
         """
 
         self.commands.extend([{"$type": "set_focus_distance",
                                "focus_distance": focus_distance},
                               {"$type": "attach_ui_canvas_to_avatar",
                                "avatar_id": avatar_id,
-                               "canvas_id": self._canvas_id}])
+                               "canvas_id": self._canvas_id,
+                               "plane_distance": plane_distance}])
 
-    def attach_canvas_to_vr_rig(self) -> None:
+    def attach_canvas_to_vr_rig(self, plane_distance: float = 0.25) -> None:
         """
         Attach the UI canvas to a VR rig.
+
+        :param plane_distance: The distance from the camera to the UI canvas.
         """
 
         self.commands.append({"$type": "attach_ui_canvas_to_vr_rig",
-                              "plane_distance": 1})
+                              "plane_distance": plane_distance})
 
     def destroy(self, ui_id: int) -> None:
         """


### PR DESCRIPTION
### `tdw` module

- Added optional field `plane_distance` to `ui.attach_canvas_to_avatar()` and `ui.attach_canvas_to_vr_rig()`. 
- The default `plane_distance` value for `ui.attach_canvas_to_vr_rig(plane_distance)` is 0.25 (was 1)