### PR TITLE
Added initial  position and rotation parameters for VR rigs

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -23,11 +23,20 @@ To upgrade from TDW v1.8 to v1.9, read [this guide](upgrade_guides/v1.8_to_v1.9.
 - Added field `impulse` to `CollisionObjObj`
 - Added optional field `plane_distance` to `ui.attach_canvas_to_avatar()` and `ui.attach_canvas_to_vr_rig()`. 
 - The default `plane_distance` value for `ui.attach_canvas_to_vr_rig(plane_distance)` is 0.25 (was 1)
+- Added optional parameters `position` (an x, y, z dictionary) and `rotation` to the constructor of `VRRig`, `VRRig.reset()`, the constructor of `OculusTouch`, and `OculusTouch.reset()`. This fixes a "bug" in which it wasn't possible to set the position of a VR rig on the same frame as when it is spawned.
 
 ### Model Library
 
 - Added to `models_core.json` and `models_full.json`: b01_trumpet, b03_trumpet_vray, b03_piccolo_trumpet_vray, b04_b200003_01, b04_baterijska_busilica, dewalt_compact_drill_vray, b03_hair_comb_2010, b04_baseball_bat, b05_racket, dumb-bell_2010
 - Removed from `models_core.json` and `models_full.json`: b03_12_06_027_composite (asset bundle doesn't exist)
+
+### Documentation
+
+#### Modified Documentation
+
+| Document                     | Modification                                                 |
+| ---------------------------- | ------------------------------------------------------------ |
+| `lessons/vr/oculus_touch.md` | Added documentation for `position` and `rotation` parameters. |
 
 ## v1.9.15
 

--- a/Documentation/lessons/vr/oculus_touch.md
+++ b/Documentation/lessons/vr/oculus_touch.md
@@ -57,6 +57,32 @@ Result:
 
 ![](images/oculus_touch/minimal.gif)
 
+### Set the initial position and rotation
+
+Set the initial position and rotation of the VR rig by setting `position` and `rotation` in the constructor or in `vr.reset()`:
+
+```python
+from tdw.controller import Controller
+from tdw.tdw_utils import TDWUtils
+from tdw.add_ons.oculus_touch import OculusTouch
+
+c = Controller()
+vr = OculusTouch(position={"x": 1, "y": 0, "z": 0}, rotation=30)
+c.add_ons.append(vr)
+c.communicate([TDWUtils.create_empty_room(12, 12),
+               c.get_add_object(model_name="rh10",
+                                object_id=Controller.get_unique_id(),
+                                position={"x": 0, "y": 0, "z": 0.5})])
+while True:
+    c.communicate([])
+```
+
+### Teleport and rotate the VR rig
+
+You can "teleport" around your scene by clicking down the left control stick; release to teleport to the location at the end of the rendered arc. This can be useful when your virtual scene space is larger than your real-world (Guardian) space, and you cannot simply walk to certain areas within your virtual space. You can programatically set the rig's position in the scene with `vr.set_position(position)`. This can be useful for initially placing yourself at a particular location within your scene.
+
+You can rotate the rig by physically turning your body. You can programatically rotate the rig with `vr.rotate_by(angle)`. This can be useful for setting the initial rotation of the rig, in order to start off facing a particular direction in your scene. 
+
 ### Button presses
 
 It can be useful to listen to button presses in order to trigger global events. In this example, we'll use `vr.listen_to_button()` to listen for a button press to trigger the end of the simulation. Note that the `button` parameter accepts an [`OculusTouchButton`](../../python/vr_data/oculus_touch_button.md) value.
@@ -411,12 +437,6 @@ The Oculus Touch rig has two hand models:
 
 Set the hand model with the optional constructor parameter `human_hands` (default is True).
 
-### Teleport and rotate the VR rig
-
-You can "teleport" around your scene by clicking down the left control stick; release to teleport to the location at the end of the rendered arc. This can be useful when your virtual scene space is larger than your real-world (Guardian) space, and you cannot simply walk to certain areas within your virtual space. You can programatically set the rig's position in the scene with `vr.set_position(position)`. This can be useful for initially placing yourself at a particular location within your scene.
-
-You can rotate the rig by physically turning your body. You can programatically rotate the rig with `vr.rotate_by(angle)`. This can be useful for setting the initial rotation of the rig, in order to start off facing a particular direction in your scene. 
-
 ### Reset
 
 Whenever you reset a scene, you must call `vr.reset()` to re-initialize the VR add-on:
@@ -463,6 +483,27 @@ c.communicate([{"$type": "load_scene",
                c.get_add_object(model_name="rh10",
                                 object_id=object_id,
                                 position={"x": 0, "y": 0, "z": 0.5})])
+c.communicate({"$type" : "terminate"})
+```
+
+You can set an initial position and rotation with the optional `position` and `rotation` parameters:
+
+```python
+from tdw.controller import Controller
+from tdw.tdw_utils import TDWUtils
+from tdw.add_ons.oculus_touch import OculusTouch
+
+c = Controller()
+vr = OculusTouch()
+c.add_ons.append(vr)
+c.communicate([TDWUtils.create_empty_room(12, 12),
+               c.get_add_object(model_name="rh10",
+                                object_id=Controller.get_unique_id(),
+                                position={"x": 0, "y": 0, "z": 0.5})])
+vr.reset(position={"x": 1, "y": 0, "z": 0}, rotation=30)
+c.communicate([{"$type": "load_scene",
+                "scene_name": "ProcGenScene"},
+               TDWUtils.create_empty_room(12, 12)])
 c.communicate({"$type" : "terminate"})
 ```
 

--- a/Documentation/python/add_ons/oculus_touch.md
+++ b/Documentation/python/add_ons/oculus_touch.md
@@ -42,13 +42,15 @@ Per-frame, update the positions of the VR rig, its hands, and its head, as well 
 
 **`OculusTouch()`**
 
-**`OculusTouch(human_hands=True, set_graspable=True, output_data=True, attach_avatar=False, avatar_camera_width=512, headset_aspect_ratio=0.9, headset_resolution_scale=1.0, non_graspable=None, discrete_collision_detection_mode=True)`**
+**`OculusTouch(human_hands=True, set_graspable=True, output_data=True, position=None, rotation=0, attach_avatar=False, avatar_camera_width=512, headset_aspect_ratio=0.9, headset_resolution_scale=1.0, non_graspable=None, discrete_collision_detection_mode=True)`**
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | human_hands |  bool  | True | If True, visualize the hands as human hands. If False, visualize the hands as robot hands. |
 | set_graspable |  bool  | True | If True, set all [non-kinematic objects](../../lessons/physx/physics_objects.md) and [composite sub-objects](../../lessons/semantic_states/composite_objects.md) as graspable by the VR rig. |
 | output_data |  bool  | True | If True, send [`VRRig` output data](../../api/output_data.md#VRRig) per-frame. |
+| position |  Dict[str, float] | None | The initial position of the VR rig. If None, defaults to `{"x": 0, "y": 0, "z": 0}` |
+| rotation |  float  | 0 | The initial rotation of the VR rig in degrees. |
 | attach_avatar |  bool  | False | If True, attach an [avatar](../../lessons/core_concepts/avatars.md) to the VR rig's head. Do this only if you intend to enable [image capture](../../lessons/core_concepts/images.md). The avatar's ID is `"vr"`. |
 | avatar_camera_width |  int  | 512 | The width of the avatar's camera in pixels. *This is not the same as the VR headset's screen resolution!* This only affects the avatar that is created if `attach_avatar` is `True`. Generally, you will want this to lower than the headset's actual pixel width, otherwise the framerate will be too slow. |
 | headset_aspect_ratio |  float  | 0.9 | The `width / height` aspect ratio of the VR headset. This is only relevant if `attach_avatar` is `True` because it is used to set the height of the output images. The default value is the correct value for all Oculus devices. |
@@ -101,13 +103,15 @@ Rotate the VR rig by an angle.
 
 **`self.reset()`**
 
-**`self.reset(non_graspable=None)`**
+**`self.reset(non_graspable=None, position=None, rotation=0)`**
 
 Reset the VR rig. Call this whenever a scene is reset.
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | non_graspable |  List[int] | None | A list of IDs of non-graspable objects. By default, all non-kinematic objects are graspable and all kinematic objects are non-graspable. Set this to make non-kinematic objects non-graspable. |
+| position |  Dict[str, float] | None | The initial position of the VR rig. If None, defaults to `{"x": 0, "y": 0, "z": 0}` |
+| rotation |  float  | 0 | The initial rotation of the VR rig in degrees. |
 
 #### before_send
 

--- a/Documentation/python/add_ons/vr.md
+++ b/Documentation/python/add_ons/vr.md
@@ -44,12 +44,14 @@ Note that this is an abstract class. Different types of VR rigs use different su
 
 **`VR(rig_type)`**
 
-**`VR(rig_type, output_data=True, attach_avatar=False, avatar_camera_width=512, headset_aspect_ratio=0.9, headset_resolution_scale=1.0)`**
+**`VR(rig_type, output_data=True, position=None, rotation=0, attach_avatar=False, avatar_camera_width=512, headset_aspect_ratio=0.9, headset_resolution_scale=1.0)`**
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | rig_type |  RigType |  | The [`RigType`](../vr_data/rig_type.md). |
 | output_data |  bool  | True | If True, send [`VRRig` output data](../../api/output_data.md#VRRig) per-frame. |
+| position |  Dict[str, float] | None | The initial position of the VR rig. If None, defaults to `{"x": 0, "y": 0, "z": 0}` |
+| rotation |  float  | 0 | The initial rotation of the VR rig in degrees. |
 | attach_avatar |  bool  | False | If True, attach an [avatar](../../lessons/core_concepts/avatars.md) to the VR rig's head. Do this only if you intend to enable [image capture](../../lessons/core_concepts/images.md). The avatar's ID is `"vr"`. |
 | avatar_camera_width |  int  | 512 | The width of the avatar's camera in pixels. *This is not the same as the VR headset's screen resolution!* This only affects the avatar that is created if `attach_avatar` is `True`. Generally, you will want this to lower than the headset's actual pixel width, otherwise the framerate will be too slow. |
 | headset_aspect_ratio |  float  | 0.9 | The `width / height` aspect ratio of the VR headset. This is only relevant if `attach_avatar` is `True` because it is used to set the height of the output images. The default value is the correct value for all Oculus devices. |
@@ -110,4 +112,11 @@ Rotate the VR rig by an angle.
 
 **`self.reset()`**
 
+**`self.reset(position=None, rotation=0)`**
+
 Reset the VR rig. Call this whenever a scene is reset.
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| position |  Dict[str, float] | None | The initial position of the VR rig. If None, defaults to `{"x": 0, "y": 0, "z": 0}` |
+| rotation |  float  | 0 | The initial rotation of the VR rig in degrees. |

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from pathlib import Path
 import re
 
-__version__ = "1.9.16.3"
+__version__ = "1.9.16.4"
 readme_path = Path('../README.md')
 if readme_path.exists():
     long_description = readme_path.read_text(encoding='utf-8')

--- a/Python/tdw/add_ons/oculus_touch.py
+++ b/Python/tdw/add_ons/oculus_touch.py
@@ -16,13 +16,16 @@ class OculusTouch(VR):
     """
 
     def __init__(self, human_hands: bool = True, set_graspable: bool = True, output_data: bool = True,
-                 attach_avatar: bool = False, avatar_camera_width: int = 512, headset_aspect_ratio: float = 0.9,
+                 position: Dict[str, float] = None, rotation: float = 0, attach_avatar: bool = False,
+                 avatar_camera_width: int = 512, headset_aspect_ratio: float = 0.9,
                  headset_resolution_scale: float = 1.0, non_graspable: List[int] = None,
                  discrete_collision_detection_mode: bool = True):
         """
         :param human_hands: If True, visualize the hands as human hands. If False, visualize the hands as robot hands.
         :param set_graspable: If True, set all [non-kinematic objects](../../lessons/physx/physics_objects.md) and [composite sub-objects](../../lessons/semantic_states/composite_objects.md) as graspable by the VR rig.
         :param output_data: If True, send [`VRRig` output data](../../api/output_data.md#VRRig) per-frame.
+        :param position: The initial position of the VR rig. If None, defaults to `{"x": 0, "y": 0, "z": 0}`
+        :param rotation: The initial rotation of the VR rig in degrees.
         :param attach_avatar: If True, attach an [avatar](../../lessons/core_concepts/avatars.md) to the VR rig's head. Do this only if you intend to enable [image capture](../../lessons/core_concepts/images.md). The avatar's ID is `"vr"`.
         :param avatar_camera_width: The width of the avatar's camera in pixels. *This is not the same as the VR headset's screen resolution!* This only affects the avatar that is created if `attach_avatar` is `True`. Generally, you will want this to lower than the headset's actual pixel width, otherwise the framerate will be too slow.
         :param headset_aspect_ratio: The `width / height` aspect ratio of the VR headset. This is only relevant if `attach_avatar` is `True` because it is used to set the height of the output images. The default value is the correct value for all Oculus devices.
@@ -35,9 +38,9 @@ class OculusTouch(VR):
             rig_type = RigType.oculus_touch_human_hands
         else:
             rig_type = RigType.oculus_touch_robot_hands
-        super().__init__(rig_type=rig_type, output_data=output_data, attach_avatar=attach_avatar,
-                         avatar_camera_width=avatar_camera_width, headset_aspect_ratio=headset_aspect_ratio,
-                         headset_resolution_scale=headset_resolution_scale)
+        super().__init__(rig_type=rig_type, output_data=output_data, position=position, rotation=rotation,
+                         attach_avatar=attach_avatar, avatar_camera_width=avatar_camera_width,
+                         headset_aspect_ratio=headset_aspect_ratio, headset_resolution_scale=headset_resolution_scale)
         self._set_graspable: bool = set_graspable
         # Button press events.
         self._button_press_events_left: Dict[OculusTouchButton, Callable[[], None]] = dict()
@@ -147,11 +150,13 @@ class OculusTouch(VR):
         else:
             self._axis_events_right.append(function)
 
-    def reset(self, non_graspable: List[int] = None) -> None:
+    def reset(self, non_graspable: List[int] = None, position: Dict[str, float] = None, rotation: float = 0) -> None:
         """
         Reset the VR rig. Call this whenever a scene is reset.
 
         :param non_graspable: A list of IDs of non-graspable objects. By default, all non-kinematic objects are graspable and all kinematic objects are non-graspable. Set this to make non-kinematic objects non-graspable.
+        :param position: The initial position of the VR rig. If None, defaults to `{"x": 0, "y": 0, "z": 0}`
+        :param rotation: The initial rotation of the VR rig in degrees.
         """
 
         self._set_graspable = True
@@ -159,4 +164,4 @@ class OculusTouch(VR):
             self._non_graspable = list()
         else:
             self._non_graspable = non_graspable
-        super().reset()
+        super().reset(position=position, rotation=rotation)

--- a/Python/tdw/add_ons/vr.py
+++ b/Python/tdw/add_ons/vr.py
@@ -21,12 +21,14 @@ class VR(AddOn, ABC):
     """
     AVATAR_ID: str = "vr"
 
-    def __init__(self, rig_type: RigType, output_data: bool = True, attach_avatar: bool = False,
-                 avatar_camera_width: int = 512, headset_aspect_ratio: float = 0.9,
-                 headset_resolution_scale: float = 1.0):
+    def __init__(self, rig_type: RigType, output_data: bool = True, position: Dict[str, float] = None,
+                 rotation: float = 0, attach_avatar: bool = False, avatar_camera_width: int = 512,
+                 headset_aspect_ratio: float = 0.9, headset_resolution_scale: float = 1.0):
         """
         :param rig_type: The [`RigType`](../vr_data/rig_type.md).
         :param output_data: If True, send [`VRRig` output data](../../api/output_data.md#VRRig) per-frame.
+        :param position: The initial position of the VR rig. If None, defaults to `{"x": 0, "y": 0, "z": 0}`
+        :param rotation: The initial rotation of the VR rig in degrees.
         :param attach_avatar: If True, attach an [avatar](../../lessons/core_concepts/avatars.md) to the VR rig's head. Do this only if you intend to enable [image capture](../../lessons/core_concepts/images.md). The avatar's ID is `"vr"`.
         :param avatar_camera_width: The width of the avatar's camera in pixels. *This is not the same as the VR headset's screen resolution!* This only affects the avatar that is created if `attach_avatar` is `True`. Generally, you will want this to lower than the headset's actual pixel width, otherwise the framerate will be too slow.
         :param headset_aspect_ratio: The `width / height` aspect ratio of the VR headset. This is only relevant if `attach_avatar` is `True` because it is used to set the height of the output images. The default value is the correct value for all Oculus devices.
@@ -36,6 +38,11 @@ class VR(AddOn, ABC):
         super().__init__()
         self._rig_type: RigType = rig_type
         self._output_data: bool = output_data
+        if position is None:
+            self._initial_position: Dict[str, float] = {"x": 0, "y": 0, "z": 0}
+        else:
+            self._initial_position = position
+        self._initial_rotation: float = rotation
         self._attach_avatar: bool = attach_avatar
         self._avatar_camera_width: int = avatar_camera_width
         self._avatar_camera_height: int = int((1 / headset_aspect_ratio) * self._avatar_camera_width)
@@ -79,7 +86,11 @@ class VR(AddOn, ABC):
                     {"$type": "set_vr_resolution_scale",
                      "resolution_scale_factor": self._headset_resolution_scale},
                     {"$type": "set_post_process",
-                     "value": False}]
+                     "value": False},
+                    {"$type": "teleport_vr_rig",
+                     "position": self._initial_position},
+                    {"$type": "rotate_vr_rig_by",
+                     "angle": self._initial_rotation}]
         # Send VR data per frame.
         if self._output_data:
             commands.append({"$type": "send_vr_rig",
@@ -144,13 +155,21 @@ class VR(AddOn, ABC):
         self.commands.append({"$type": "rotate_vr_rig_by",
                               "angle": angle})
 
-    def reset(self) -> None:
+    def reset(self, position: Dict[str, float] = None, rotation: float = 0) -> None:
         """
         Reset the VR rig. Call this whenever a scene is reset.
+
+        :param position: The initial position of the VR rig. If None, defaults to `{"x": 0, "y": 0, "z": 0}`
+        :param rotation: The initial rotation of the VR rig in degrees.
         """
 
         self.initialized = False
         self.commands.clear()
+        if position is None:
+            self._initial_position = {"x": 0, "y": 0, "z": 0}
+        else:
+            self._initial_position = position
+        self._initial_rotation: float = rotation
         self.rig = VR._get_empty_transform()
         self.left_hand = VR._get_empty_transform()
         self.right_hand = VR._get_empty_transform()


### PR DESCRIPTION
- Added optional parameters `position` (an x, y, z dictionary) and `rotation` to the constructor of `VRRig`, `VRRig.reset()`, the constructor of `OculusTouch`, and `OculusTouch.reset()`. This fixes a "bug" in which it wasn't possible to set the position of a VR rig on the same frame as when it is spawned.
- Updated `lessons/vr/oculus_touch.md` with code examples