### PR TITLE
Updated docker start scripts to use "tdw_version.py"

### DIFF
--- a/Docker/start_container.sh
+++ b/Docker/start_container.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=$(./tdw_version.sh)
+VERSION=$(python3 ./tdw_version.py)
 
 # Allow x server to accept local connections
 xhost +local:root

--- a/Docker/start_container_audio_video.sh
+++ b/Docker/start_container_audio_video.sh
@@ -1,5 +1,5 @@
 
-VERSION=$(./tdw_version.sh)
+VERSION=$(python3 ./tdw_version.py)
 
 docker run -it \
   --rm \

--- a/Docker/start_container_xpra.sh
+++ b/Docker/start_container_xpra.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=$(./tdw_version.sh)
+VERSION=$(python3 ./tdw_version.py)
 
 
 # Allow x server to accept local connections


### PR DESCRIPTION
Hi all,
I was trying to run TDW via docker containers as explained here https://github.com/threedworld-mit/tdw/blob/master/Documentation/lessons/setup/install.md#install-tdw-in-a-docker-container. 
When running the example launch script mentioned (Step 7), this error came up
`./start_container.sh: line 3: ./tdw_version.sh: No such file or directory`
I believe this might be caused by referencing a file that is no longer present in the code. I changed the docker startup scripts to follow the method used in `./Docker/pull.sh script` (https://github.com/threedworld-mit/tdw/blob/15354427161d19b6a8f437ac622012a59e78b301/Docker/pull.sh).

Please let me know if this was a mistake by my end.

All the best