### PR TITLE
Added optional parameter device_name to PhysicsAudioRecorder

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -22,6 +22,10 @@ To upgrade from TDW v1.9 to v1.10, read [this guide](upgrade_guides/v1.9_to_v1.1
 | ------------- | ------------------------------------------ |
 | `FieldOfView` | The camera field of view and focal length. |
 
+### `tdw` module
+
+- Added optional parameter `device_name` to `PhysicsAudioRecorder.start()`.
+
 ### Model Library
 
 - Flagged b04_wallmounted_soap_dispenser_composite as do_not_use (missing asset bundles)

--- a/Documentation/python/add_ons/physics_audio_recorder.md
+++ b/Documentation/python/add_ons/physics_audio_recorder.md
@@ -68,13 +68,14 @@ This is called before sending commands to the build. By default, this function d
 
 **`self.start()`**
 
-**`self.start(path=None)`**
+**`self.start(path=None, device_name=None)`**
 
 Start recording.
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | path |  Union[str, Path] | None | The path to the output .wav file. If None, defaults to the current working directory. |
+| device_name |  str  | None | The name of the audio capture device. If None, defaults to `"Stereo Mix"` (Windows and Linux) or `"iShowU Audio Capture"` (OS X). |
 
 #### stop
 

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from pathlib import Path
 import re
 
-__version__ = "1.10.1.1"
+__version__ = "1.10.1.2"
 readme_path = Path('../README.md')
 if readme_path.exists():
     long_description = readme_path.read_text(encoding='utf-8')

--- a/Python/tdw/add_ons/physics_audio_recorder.py
+++ b/Python/tdw/add_ons/physics_audio_recorder.py
@@ -79,11 +79,12 @@ class PhysicsAudioRecorder(AddOn):
         if sleeping and not playing_audio:
             self.stop()
 
-    def start(self, path: Union[str, Path] = None) -> None:
+    def start(self, path: Union[str, Path] = None, device_name: str = None) -> None:
         """
         Start recording.
 
         :param path: The path to the output .wav file. If None, defaults to the current working directory.
+        :param device_name: The name of the audio capture device. If None, defaults to `"Stereo Mix"` (Windows and Linux) or `"iShowU Audio Capture"` (OS X).
         """
 
         # Don't start a new recording if one is ongoing.
@@ -104,7 +105,7 @@ class PhysicsAudioRecorder(AddOn):
         self._frame = 0
         # Start listening.
         if self._record_audio:
-            AudioUtils.start(output_path=self.path)
+            AudioUtils.start(output_path=self.path, device_name=device_name)
         self.commands.extend([{"$type": "send_audio_sources",
                                "frequency": "always"},
                               {"$type": "send_rigidbodies",


### PR DESCRIPTION
### `tdw` module

- Added optional parameter `device_name` to `PhysicsAudioRecorder.start()`.