### PR TITLE
ffmpeg bugs on OSX

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -8,7 +8,16 @@ To upgrade from TDW v1.9 to v1.10, read [this guide](upgrade_guides/v1.9_to_v1.1
 
 ### Build
 
-- Fixed: `set_screen_size` doesn't wait until the window is done resizing, resulting in occasional errors in video capture commands such as `start_video_capture_windows` as well as in `send_images`. 
+- Fixed: `set_screen_size` doesn't wait until the window is done resizing, resulting in occasional errors in video capture commands such as `start_video_capture_windows` as well as in `send_images`.
+- Fixed: `start_video_capture_osx` fails if `"audio"` is set to `False`.
+
+### Documentation
+
+#### Modified Documentation
+
+| Document                                                     | Modification                                                 |
+| ------------------------------------------------------------ | ------------------------------------------------------------ |
+| `lessons/video/screen_record_linux.d`<br>`lessons/video/screen_record_osx.md`<br>`lessons/video/screen_record_windows.md` | Clarified how to use `log_args` to check for ffmpeg errors and listed a few common errors plus their solutions. |
 
 ## v1.10.6
 

--- a/Documentation/api/command_api.md
+++ b/Documentation/api/command_api.md
@@ -8656,7 +8656,7 @@ Start video capture using ffmpeg. This command can only be used on Linux.
 | `"display"` | int | The X11 display index. To review your X11 setup: cat /etc/X11/xorg.conf | 0 |
 | `"screen"` | int | The X11 screen index. To review your X11 setup: cat /etc/X11/xorg.conf | 0 |
 | `"audio_device"` | string | The pulseaudio device name. Ignored if audio == False. To get a list of devices: pactl list sources | grep output | "alsa_output.pci-0000_00_1f.3.analog-stereo.monitor" |
-| `"output_path"` | string | The absolute path to the output file, e.g. /home/user/video.mkv | |
+| `"output_path"` | string | The absolute path to the output file, e.g. /home/user/video.mp4 | |
 | `"ffmpeg"` | string | The path to the ffmpeg process. Set this parameter only if you're using a non-standard path. | "" |
 | `"overwrite"` | bool | If True, overwrite the video if it already exists. | True |
 | `"framerate"` | int | The framerate of the output video. | 60 |
@@ -8690,7 +8690,7 @@ Start video capture using ffmpeg. This command can only be used on OS X.
 | `"audio_device"` | int | The audio device index. Ignored if audio == False. To get a list of devices: ffmpeg -f avfoundation -list_devices true -i "" | 0 |
 | `"size_scale_factor"` | int | On retina screens, the actual window size is scaled. Set this scale factor to scale the video capture size. | 2 |
 | `"position_scale_factor"` | int | On retina screens, the actual window size is scaled. Set this scale factor to scale the video capture position. | 2 |
-| `"output_path"` | string | The absolute path to the output file, e.g. /home/user/video.mkv | |
+| `"output_path"` | string | The absolute path to the output file, e.g. /home/user/video.mp4 | |
 | `"ffmpeg"` | string | The path to the ffmpeg process. Set this parameter only if you're using a non-standard path. | "" |
 | `"overwrite"` | bool | If True, overwrite the video if it already exists. | True |
 | `"framerate"` | int | The framerate of the output video. | 60 |
@@ -8723,7 +8723,7 @@ Start video capture using ffmpeg. This command can only be used on Windows.
 | `"audio_device"` | string | The name of the audio device. Ignored if audio == False. To get a list of devices: ffmpeg -list_devices true -f dshow -i dummy | "" |
 | `"audio_buffer_size"` | int | The audio buffer size in ms. This should always be greater than 0. Adjust this if the audio doesn't sync with the video. See: <ulink url="https://ffmpeg.org/ffmpeg-devices.html">https://ffmpeg.org/ffmpeg-devices.html</ulink> (search for audio_buffer_size). | 5 |
 | `"draw_mouse"` | bool | If True, show the mouse in the video. | False |
-| `"output_path"` | string | The absolute path to the output file, e.g. /home/user/video.mkv | |
+| `"output_path"` | string | The absolute path to the output file, e.g. /home/user/video.mp4 | |
 | `"ffmpeg"` | string | The path to the ffmpeg process. Set this parameter only if you're using a non-standard path. | "" |
 | `"overwrite"` | bool | If True, overwrite the video if it already exists. | True |
 | `"framerate"` | int | The framerate of the output video. | 60 |

--- a/Documentation/lessons/video/screen_record_linux.md
+++ b/Documentation/lessons/video/screen_record_linux.md
@@ -182,14 +182,27 @@ To stop video capture, send [`stop_video_capture`](../../api/command_api.md#stop
 
 ## What to do if there is no video
 
-- [Check the player log.](https://docs.unity3d.com/Manual/LogFiles.html) It will usually tell you what the error was.
-- Set the optional `log_args` parameter to `True` to log the ffmpeg args. This can allow you to replicate the exact ffmpeg call:
+1. Set the optional `log_args` parameter to `True` to log the ffmpeg args. This can allow you to replicate the exact ffmpeg call:
 
 ```
 {"$type": "start_video_capture_osx",
  "output_path": str(path.resolve()),
  "log_args": True}
 ```
+
+2. [Check the player log.](https://docs.unity3d.com/Manual/LogFiles.html) It will have a line that looks like this:
+
+```
+-f pulse -i alsa_output.pci-0000_00_1f.3.analog-stereo.monitor -c:a aac -ac 2 -video_size 256x256 -framerate 60 -f x11grab -i :0.0+952,1840 -c:v h264 -qp 0 -preset ultrafast -y "/home/user/tdw_example_controller_output/video_capture/video.mp4" [TDWInput.StartVideoCaptureLinux]
+```
+
+3. In a terminal, type `ffmpeg` plus the arguments in the Player log:
+
+```bash
+ffmpeg -f pulse -i alsa_output.pci-0000_00_1f.3.analog-stereo.monitor -c:a aac -ac 2 -video_size 256x256 -framerate 60 -f x11grab -i :0.0+952,1840 -c:v h264 -qp 0 -preset ultrafast -y "/home/user/tdw_example_controller_output/video_capture/video.mp4" 
+```
+
+4. If the ffmpeg process has an error, read the error carefully and adjust your command's parameters accordingly. An error regarding displays, for example, usually means that your `display` or `screen` paramter is wrong. If, on the other hand, there is no error, you can press `q` to quit.
 
 ## What to do if the video doesn't open
 

--- a/Documentation/lessons/video/screen_record_osx.md
+++ b/Documentation/lessons/video/screen_record_osx.md
@@ -144,29 +144,41 @@ To stop video capture, send [`stop_video_capture`](../../api/command_api.md#stop
 
 ## What to do if there is no video
 
-- [Check the player log.](https://docs.unity3d.com/Manual/LogFiles.html) It will usually tell you what the error was.
-- Set the optional `log_args` parameter to `True` to log the ffmpeg args. This can allow you to replicate the exact ffmpeg call:
+1. Set the optional `log_args` parameter to `True` to log the ffmpeg args. This can allow you to replicate the exact ffmpeg call:
 
 ```
-{"$type": "start_video_capture_osx",
+{"$type": "start_video_capture_windows",
  "output_path": str(path.resolve()),
  "log_args": True}
 ```
+
+2. [Check the player log.](https://docs.unity3d.com/Manual/LogFiles.html) It will have a line that looks like this:
+
+```
+-f avfoundation -i "1:0" -vsync 0 -framerate 60 -filter:v"crop=512:512,1792:956" -c:v h264 -qp 0 -preset ultrafast -y "/Users/user/tdw_example_controller_output/video_capture/video.mp4" [TDWInput.StartVideoCaptureOsx]
+```
+
+3. In a terminal, type `ffmpeg` plus the arguments in the Player log:
+
+```bash
+ffmpeg -f avfoundation -i "1:0" -vsync 0 -framerate 60 -filter:v"crop=512:512,1792:956" -c:v h264 -qp 0 -preset ultrafast -y "/Users/user/tdw_example_controller_output/video_capture/video.mp4" 
+```
+
+4. If the ffmpeg process has an error, read the error carefully. An audio-related error, for example, usually means that your `"audio_device"` is wrong. If, on the other hand, there is no error, you can press `q` to quit.
+
+*If you get an error about the framerate:* On some (but not all) machines, you may get an error like this:
+
+```
+[avfoundation @ 0x7fe0d2800000] Selected framerate (29.970030) is not supported by the device
+```
+
+If you see this error, the framerate you have selected (60 by default) isn't supported on your machine. Set `"framerate": 30` in your command.
 
 ## What to do if the video doesn't open
 
 Open the video in VLC. 
 
 If the video file size is very low (e.g. 48 bytes or 0 bytes), there was an error in video capture; see above for how to troubleshoot.
-
-## What to do if you get an error about framerate
-
-On some (but not all) machines, you may get an error like this:
-```
-[avfoundation @ 0x7fe0d2800000] Selected framerate (29.970030) is not supported by the device
-```
-
-If you see this error, the framerate you have selected (60 by default) isn't supported on your machine. Set `"framerate": 30` in your command.
 
 ***
 

--- a/Documentation/lessons/video/screen_record_osx.md
+++ b/Documentation/lessons/video/screen_record_osx.md
@@ -159,6 +159,15 @@ Open the video in VLC.
 
 If the video file size is very low (e.g. 48 bytes or 0 bytes), there was an error in video capture; see above for how to troubleshoot.
 
+## What to do if you get an error about framerate
+
+On some (but not all) machines, you may get an error like this:
+```
+[avfoundation @ 0x7fe0d2800000] Selected framerate (29.970030) is not supported by the device
+```
+
+If you see this error, the framerate you have selected (60 by default) isn't supported on your machine. Set `"framerate": 30` in your command.
+
 ***
 
 **This is the last document in the "Video Recording" tutorial.**

--- a/Documentation/lessons/video/screen_record_osx.md
+++ b/Documentation/lessons/video/screen_record_osx.md
@@ -147,7 +147,7 @@ To stop video capture, send [`stop_video_capture`](../../api/command_api.md#stop
 1. Set the optional `log_args` parameter to `True` to log the ffmpeg args. This can allow you to replicate the exact ffmpeg call:
 
 ```
-{"$type": "start_video_capture_windows",
+{"$type": "start_video_capture_osx",
  "output_path": str(path.resolve()),
  "log_args": True}
 ```
@@ -164,7 +164,7 @@ To stop video capture, send [`stop_video_capture`](../../api/command_api.md#stop
 ffmpeg -f avfoundation -i "1:0" -vsync 0 -framerate 60 -filter:v"crop=512:512,1792:956" -c:v h264 -qp 0 -preset ultrafast -y "/Users/user/tdw_example_controller_output/video_capture/video.mp4" 
 ```
 
-4. If the ffmpeg process has an error, read the error carefully. An audio-related error, for example, usually means that your `"audio_device"` is wrong. If, on the other hand, there is no error, you can press `q` to quit.
+4. If the ffmpeg process has an error, read the error carefully and adjust your command's parameters accordingly. An audio-related error, for example, usually means that your `"audio_device"` is wrong. If, on the other hand, there is no error, you can press `q` to quit.
 
 *If you get an error about the framerate:* On some (but not all) machines, you may get an error like this:
 

--- a/Documentation/lessons/video/screen_record_windows.md
+++ b/Documentation/lessons/video/screen_record_windows.md
@@ -155,14 +155,27 @@ To stop video capture, send [`stop_video_capture`](../../api/command_api.md#stop
 
 ## What to do if there is no video
 
-- [Check the player log.](https://docs.unity3d.com/Manual/LogFiles.html) It will usually tell you what the error was.
-- Set the optional `log_args` parameter to `True` to log the ffmpeg args. This can allow you to replicate the exact ffmpeg call:
+1. Set the optional `log_args` parameter to `True` to log the ffmpeg args. This can allow you to replicate the exact ffmpeg call:
 
 ```
 {"$type": "start_video_capture_windows",
  "output_path": str(path.resolve()),
  "log_args": True}
 ```
+
+2. [Check the player log.](https://docs.unity3d.com/Manual/LogFiles.html) It will have a line that looks like this:
+
+```
+-audio_buffer_size 5 -f dshow -i audio="Stereo Mix (Realtek(R) Audio)" -c:a aac -ac 2 -f gdigrab -draw_mouse 0 -framerate 60 -offset_x 952 -offset_y 1817 -video_size 256x256 -i desktop -c:v h264 -qp 0 -preset ultrafast -y "C:\Users\user\tdw_example_controller_output\video_capture\video.mp4" [TDWInput.StartVideoCaptureWindows]
+```
+
+3. In a terminal, type `ffmpeg` plus the arguments in the Player log:
+
+```bash
+ffmpeg -audio_buffer_size 5 -f dshow -i audio="Stereo Mix (Realtek(R) Audio)" -c:a aac -ac 2 -f gdigrab -draw_mouse 0 -framerate 60 -offset_x 952 -offset_y 1817 -video_size 256x256 -i desktop -c:v h264 -qp 0 -preset ultrafast -y "C:\Users\user\tdw_example_controller_output\video_capture\video.mp4" 
+```
+
+4. If the ffmpeg process has an error, read the error carefully. An audio-related error, for example, usually means that your `"audio_device"` is wrong. If, on the other hand, there is no error, you can press `q` to quit.
 
 ## What to do if the video doesn't open
 

--- a/Documentation/lessons/video/screen_record_windows.md
+++ b/Documentation/lessons/video/screen_record_windows.md
@@ -175,7 +175,7 @@ To stop video capture, send [`stop_video_capture`](../../api/command_api.md#stop
 ffmpeg -audio_buffer_size 5 -f dshow -i audio="Stereo Mix (Realtek(R) Audio)" -c:a aac -ac 2 -f gdigrab -draw_mouse 0 -framerate 60 -offset_x 952 -offset_y 1817 -video_size 256x256 -i desktop -c:v h264 -qp 0 -preset ultrafast -y "C:\Users\user\tdw_example_controller_output\video_capture\video.mp4" 
 ```
 
-4. If the ffmpeg process has an error, read the error carefully. An audio-related error, for example, usually means that your `"audio_device"` is wrong. If, on the other hand, there is no error, you can press `q` to quit.
+4. If the ffmpeg process has an error, read the error carefully and adjust your command's parameters accordingly. An audio-related error, for example, usually means that your `"audio_device"` is wrong. If, on the other hand, there is no error, you can press `q` to quit.
 
 ## What to do if the video doesn't open
 


### PR DESCRIPTION
### Build

- Fixed: `set_screen_size` doesn't wait until the window is done resizing, resulting in occasional errors in video capture commands such as `start_video_capture_windows` as well as in `send_images`.
- Fixed: `start_video_capture_osx` fails if `"audio"` is set to `False`.

### Documentation

#### Modified Documentation

| Document                                                     | Modification                                                 |
| ------------------------------------------------------------ | ------------------------------------------------------------ |
| `lessons/video/screen_record_linux.d`<br>`lessons/video/screen_record_osx.md`<br>`lessons/video/screen_record_windows.md` | Clarified how to use `log_args` to check for ffmpeg errors and listed a few common errors plus their solutions. |