### PR TITLE
Fixed: video tends to not be playable in applications other than VLC

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -15,6 +15,12 @@ To upgrade from TDW v1.9 to v1.10, read [this guide](upgrade_guides/v1.9_to_v1.1
 | `teleport_avatar_by`     | Teleport an avatar by a position offset.                     |
 | `add_visual_camera_mesh` | Add a visual camera mesh to the sensor container. The visual mesh won't have colliders and won't respond to physics. |
 
+#### Modified Commands
+
+| Command                                                      | Modification                                                 |
+| ------------------------------------------------------------ | ------------------------------------------------------------ |
+| `start_video_capture_linux`<br>`start_video_capture_osx`<br>`start_video_capture_window` | Added an optional parameter `pixel_format` that defaults to `"yuv420p"` and set the default value of `qp` to 1 (was 0). Because of these changes, the generated .mp4 video is much more likely to be playable in programs other than VLC. |
+
 ## v1.10.7
 
 ### Command API

--- a/Documentation/api/command_api.md
+++ b/Documentation/api/command_api.md
@@ -8693,7 +8693,7 @@ Start video capture using ffmpeg. This command can only be used on Linux.
 ```
 
 ```python
-{"$type": "start_video_capture_linux", "output_path": "string", "display": 0, "screen": 0, "audio_device": "alsa_output.pci-0000_00_1f.3.analog-stereo.monitor", "ffmpeg": "", "overwrite": True, "framerate": 60, "position": {"x": 0, "y": 0}, "audio": True, "audio_codec": "aac", "video_codec": "h264", "preset": "ultrafast", "qp": 0, "log_args": False, "override_args": ""}
+{"$type": "start_video_capture_linux", "output_path": "string", "display": 0, "screen": 0, "audio_device": "alsa_output.pci-0000_00_1f.3.analog-stereo.monitor", "ffmpeg": "", "overwrite": True, "framerate": 60, "position": {"x": 0, "y": 0}, "audio": True, "audio_codec": "aac", "video_codec": "h264", "preset": "ultrafast", "qp": 1, "pixel_format": "yuv420p", "log_args": False, "override_args": ""}
 ```
 
 | Parameter | Type | Description | Default |
@@ -8710,7 +8710,8 @@ Start video capture using ffmpeg. This command can only be used on Linux.
 | `"audio_codec"` | string | The audio codec. You should usually keep this set to the default value. See: <ulink url="https://ffmpeg.org/ffmpeg-codecs.html">https://ffmpeg.org/ffmpeg-codecs.html</ulink> | "aac" |
 | `"video_codec"` | string | The video codec. You should usually keep this set to the default value. See: <ulink url="https://ffmpeg.org/ffmpeg-codecs.html">https://ffmpeg.org/ffmpeg-codecs.html</ulink> | "h264" |
 | `"preset"` | string | H.264 video encoding only. A preset of parameters that affect encoding speed and compression. See: <ulink url="https://trac.ffmpeg.org/wiki/Encode/H.264">https://trac.ffmpeg.org/wiki/Encode/H.264</ulink> | "ultrafast" |
-| `"qp"` | int | H.264 video encoding only. This controls the video quality. 0 is lossless. | 0 |
+| `"qp"` | int | H.264 video encoding only. This controls the video quality. 0 is lossless. | 1 |
+| `"pixel_format"` | string | The pixel format. You should almost never need to set this to anything other than the default value. | "yuv420p" |
 | `"log_args"` | bool | If True, log the command-line arguments to the player log (this can additionally be received by the controller via the send_log_messages command). | False |
 | `"override_args"` | string | If not empty, replace the ffmpeg arguments with this string. Usually, you won't want to set this. If you want to use ffmpeg for something other than screen recording, consider launching it from a Python script using subprocess.call(). | "" |
 
@@ -8726,7 +8727,7 @@ Start video capture using ffmpeg. This command can only be used on OS X.
 ```
 
 ```python
-{"$type": "start_video_capture_osx", "output_path": "string", "video_device": 1, "audio_device": 0, "size_scale_factor": 2, "position_scale_factor": 2, "ffmpeg": "", "overwrite": True, "framerate": 60, "position": {"x": 0, "y": 0}, "audio": True, "audio_codec": "aac", "video_codec": "h264", "preset": "ultrafast", "qp": 0, "log_args": False, "override_args": ""}
+{"$type": "start_video_capture_osx", "output_path": "string", "video_device": 1, "audio_device": 0, "size_scale_factor": 2, "position_scale_factor": 2, "ffmpeg": "", "overwrite": True, "framerate": 60, "position": {"x": 0, "y": 0}, "audio": True, "audio_codec": "aac", "video_codec": "h264", "preset": "ultrafast", "qp": 1, "pixel_format": "yuv420p", "log_args": False, "override_args": ""}
 ```
 
 | Parameter | Type | Description | Default |
@@ -8744,7 +8745,8 @@ Start video capture using ffmpeg. This command can only be used on OS X.
 | `"audio_codec"` | string | The audio codec. You should usually keep this set to the default value. See: <ulink url="https://ffmpeg.org/ffmpeg-codecs.html">https://ffmpeg.org/ffmpeg-codecs.html</ulink> | "aac" |
 | `"video_codec"` | string | The video codec. You should usually keep this set to the default value. See: <ulink url="https://ffmpeg.org/ffmpeg-codecs.html">https://ffmpeg.org/ffmpeg-codecs.html</ulink> | "h264" |
 | `"preset"` | string | H.264 video encoding only. A preset of parameters that affect encoding speed and compression. See: <ulink url="https://trac.ffmpeg.org/wiki/Encode/H.264">https://trac.ffmpeg.org/wiki/Encode/H.264</ulink> | "ultrafast" |
-| `"qp"` | int | H.264 video encoding only. This controls the video quality. 0 is lossless. | 0 |
+| `"qp"` | int | H.264 video encoding only. This controls the video quality. 0 is lossless. | 1 |
+| `"pixel_format"` | string | The pixel format. You should almost never need to set this to anything other than the default value. | "yuv420p" |
 | `"log_args"` | bool | If True, log the command-line arguments to the player log (this can additionally be received by the controller via the send_log_messages command). | False |
 | `"override_args"` | string | If not empty, replace the ffmpeg arguments with this string. Usually, you won't want to set this. If you want to use ffmpeg for something other than screen recording, consider launching it from a Python script using subprocess.call(). | "" |
 
@@ -8760,7 +8762,7 @@ Start video capture using ffmpeg. This command can only be used on Windows.
 ```
 
 ```python
-{"$type": "start_video_capture_windows", "output_path": "string", "audio_device": "", "audio_buffer_size": 5, "draw_mouse": False, "ffmpeg": "", "overwrite": True, "framerate": 60, "position": {"x": 0, "y": 0}, "audio": True, "audio_codec": "aac", "video_codec": "h264", "preset": "ultrafast", "qp": 0, "log_args": False, "override_args": ""}
+{"$type": "start_video_capture_windows", "output_path": "string", "audio_device": "", "audio_buffer_size": 5, "draw_mouse": False, "ffmpeg": "", "overwrite": True, "framerate": 60, "position": {"x": 0, "y": 0}, "audio": True, "audio_codec": "aac", "video_codec": "h264", "preset": "ultrafast", "qp": 1, "pixel_format": "yuv420p", "log_args": False, "override_args": ""}
 ```
 
 | Parameter | Type | Description | Default |
@@ -8777,7 +8779,8 @@ Start video capture using ffmpeg. This command can only be used on Windows.
 | `"audio_codec"` | string | The audio codec. You should usually keep this set to the default value. See: <ulink url="https://ffmpeg.org/ffmpeg-codecs.html">https://ffmpeg.org/ffmpeg-codecs.html</ulink> | "aac" |
 | `"video_codec"` | string | The video codec. You should usually keep this set to the default value. See: <ulink url="https://ffmpeg.org/ffmpeg-codecs.html">https://ffmpeg.org/ffmpeg-codecs.html</ulink> | "h264" |
 | `"preset"` | string | H.264 video encoding only. A preset of parameters that affect encoding speed and compression. See: <ulink url="https://trac.ffmpeg.org/wiki/Encode/H.264">https://trac.ffmpeg.org/wiki/Encode/H.264</ulink> | "ultrafast" |
-| `"qp"` | int | H.264 video encoding only. This controls the video quality. 0 is lossless. | 0 |
+| `"qp"` | int | H.264 video encoding only. This controls the video quality. 0 is lossless. | 1 |
+| `"pixel_format"` | string | The pixel format. You should almost never need to set this to anything other than the default value. | "yuv420p" |
 | `"log_args"` | bool | If True, log the command-line arguments to the player log (this can additionally be received by the controller via the send_log_messages command). | False |
 | `"override_args"` | string | If not empty, replace the ffmpeg arguments with this string. Usually, you won't want to set this. If you want to use ffmpeg for something other than screen recording, consider launching it from a Python script using subprocess.call(). | "" |
 


### PR DESCRIPTION
### Command API

#### Modified Commands

| Command                                                      | Modification                                                 |
| ------------------------------------------------------------ | ------------------------------------------------------------ |
| `start_video_capture_linux`<br>`start_video_capture_osx`<br>`start_video_capture_window` | Added an optional parameter `pixel_format` that defaults to `"yuv420p"` and set the default value of `qp` to 1 (was 0). Because of these changes, the generated .mp4 video is much more likely to be playable in programs other than VLC. |