### PR TITLE
Fixed: FirstPersonAvatar crashes due to missing _raycast_id parameter.

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -30,6 +30,7 @@ To upgrade from TDW v1.9 to v1.10, read [this guide](upgrade_guides/v1.10_to_v1.
 - The Replicant now has a default initialization action. After initialization, the Replicant captures an initial image.
 - Added: `replicant.dynamic.get_pil_image(pass_mask)` Convert raw image data to a PIL Image.
 - Fixed: Broken link for the `replicant_0` OS X asset bundle.
+- Fixed: `FirstPersonAvatar` crashes due to missing `_raycast_id` parameter.
 
 ### Build
 

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from pathlib import Path
 import re
 
-__version__ = "1.11.1.1"
+__version__ = "1.11.1.2"
 readme_path = Path('../README.md')
 if readme_path.exists():
     long_description = readme_path.read_text(encoding='utf-8')

--- a/Python/tdw/add_ons/first_person_avatar.py
+++ b/Python/tdw/add_ons/first_person_avatar.py
@@ -1,3 +1,4 @@
+from os import urandom
 from base64 import b64encode
 from io import BytesIO
 from secrets import token_urlsafe
@@ -61,6 +62,7 @@ class FirstPersonAvatar(Mouse):
         self._look_x_limit: float = look_x_limit
         self._framerate: int = framerate
         self._reticule_size: int = reticule_size
+        self._raycast_id: int = int.from_bytes(urandom(3), byteorder='big')
         """:field
         The [`Transform`](../object_data/transform.md) of the avatar.
         """


### PR DESCRIPTION
Fixed: `FirstPersonAvatar` crashes due to missing `_raycast_id` parameter.