### PR TITLE
Standardized Oculus Touch input mapping

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -14,13 +14,13 @@ To upgrade from TDW v1.9 to v1.10, read [this guide](upgrade_guides/v1.10_to_v1.
 
 - Standardized the Oculus Touch input mapping in all examples in `vr/`: Click the left control stick to quit and press Y for a new trial/scene.
 
-### Documentaiton
+### Documentation
+
+#### Modified Documentation
 
 | Document                     | Modification                                                 |
 | ---------------------------- | ------------------------------------------------------------ |
 | `lessons/vr/oculus_touch.md` | Fixed the example code to standardize Oculus Touch input mapping: Click the left control stick to quit and press Y for a new trial/scene. |
-
-
 
 ## v1.11.1
 

--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -10,6 +10,18 @@ To upgrade from TDW v1.9 to v1.10, read [this guide](upgrade_guides/v1.10_to_v1.
 
 - (Backend) Updated the Oculus Touch rig's AutoHand system from 2.1.0 to 3.1.3, which improves performance, physics behavior, and hand poses.
 
+### Example Controllers
+
+- Standardized the Oculus Touch input mapping in all examples in `vr/`: Click the left control stick to quit and press Y for a new trial/scene.
+
+### Documentaiton
+
+| Document                     | Modification                                                 |
+| ---------------------------- | ------------------------------------------------------------ |
+| `lessons/vr/oculus_touch.md` | Fixed the example code to standardize Oculus Touch input mapping: Click the left control stick to quit and press Y for a new trial/scene. |
+
+
+
 ## v1.11.1
 
 ### Command API

--- a/Documentation/lessons/vr/oculus_touch.md
+++ b/Documentation/lessons/vr/oculus_touch.md
@@ -103,8 +103,8 @@ class VirtualReality(Controller):
         super().__init__(port=port, check_version=check_version, launch_build=launch_build)
         self.done = False
         self.vr = OculusTouch()
-        # Quit when the left trigger button is pressed.
-        self.vr.listen_to_button(button=OculusTouchButton.trigger_button, is_left=True, function=self.quit)
+        # Quit when the left control stick is clicked.
+        self.vr.listen_to_button(button=OculusTouchButton.primary_2d_axis_click, is_left=True, function=self.quit)
         self.add_ons.extend([self.vr])
 
     def run(self) -> None:
@@ -150,8 +150,8 @@ class OculusTouchButtonListener(Controller):
         self.vr = OculusTouch()
         # Quit when the left trigger button is pressed.
         self.vr.listen_to_button(button=OculusTouchButton.trigger_button, is_left=True, function=self.quit)
-        # End the trial when the right trigger button is pressed.
-        self.vr.listen_to_button(button=OculusTouchButton.trigger_button, is_left=False, function=self.end_trial)
+        # End the trial when the Y button is pressed.
+        self.vr.listen_to_button(button=OculusTouchButton.secondary_button, is_left=True, function=self.end_trial)
         self.add_ons.extend([self.vr])
         self.communicate(TDWUtils.create_empty_room(12, 12))
 
@@ -226,8 +226,8 @@ class OculusTouchAxisListener(Controller):
         # Move the robot joints with the control sticks.
         self.vr.listen_to_axis(is_left=True, function=self.left_axis)
         self.vr.listen_to_axis(is_left=False, function=self.right_axis)
-        # Quit when the left trigger button is pressed.
-        self.vr.listen_to_button(button=OculusTouchButton.trigger_button, is_left=True, function=self.quit)
+        # Quit when the left control stick is clicked.
+        self.vr.listen_to_button(button=OculusTouchButton.primary_2d_axis_click, is_left=True, function=self.quit)
         self.add_ons.extend([self.robot, self.vr])
         self.done: bool = False
 
@@ -314,8 +314,8 @@ class OculusTouchCompositeObject(Controller):
         self.done = False
         # Add the VR rig.
         self.vr = OculusTouch(human_hands=False, output_data=True, attach_avatar=True, set_graspable=False)
-        # Quit when the left trigger button is pressed.
-        self.vr.listen_to_button(button=OculusTouchButton.trigger_button, is_left=True, function=self.quit)
+        # Quit when the left control stick is clicked.
+        self.vr.listen_to_button(button=OculusTouchButton.primary_2d_axis_click, is_left=True, function=self.quit)
         self.add_ons.append(self.vr)
 
     def run(self) -> None:
@@ -456,10 +456,10 @@ class LoadingScreen(Controller):
         # Add a VR rig.
         self.vr: OculusTouch = OculusTouch()
         self.done: bool = False
-        # Quit when the left trigger button is pressed.
-        self.vr.listen_to_button(button=OculusTouchButton.trigger_button, is_left=True, function=self.quit)
-        # Go to the next scene when the right trigger button is pressed.
-        self.vr.listen_to_button(button=OculusTouchButton.trigger_button, is_left=False, function=self.next_trial)
+        # Quit when the left control stick is clicked.
+        self.vr.listen_to_button(button=OculusTouchButton.primary_2d_axis_click, is_left=True, function=self.quit)
+        # Go to the next scene when the Y button is pressed.
+        self.vr.listen_to_button(button=OculusTouchButton.secondary_button, is_left=True, function=self.next_trial)
         self.add_ons.append(self.vr)
         # Load the first scene.
         self.next_trial()
@@ -614,10 +614,10 @@ class OculusTouchPyImpact(Controller):
         self.simulation_done = False
         self.trial_done = False
         self.vr = OculusTouch(set_graspable=False)
-        # Quit when the left trigger button is pressed.
-        self.vr.listen_to_button(button=OculusTouchButton.trigger_button, is_left=True, function=self.quit)
-        # End the trial when the right trigger button is pressed.
-        self.vr.listen_to_button(button=OculusTouchButton.trigger_button, is_left=False, function=self.end_trial)
+        # Quit when the left control stick is clicked.
+        self.vr.listen_to_button(button=OculusTouchButton.primary_2d_axis_click, is_left=True, function=self.quit)
+        # End the trial when the Y button is pressed.
+        self.vr.listen_to_button(button=OculusTouchButton.secondary_button, is_left=True, function=self.end_trial)
         # Enable PyImpact.
         self.py_impact = PyImpact()
         self.add_ons.extend([self.vr, self.py_impact])

--- a/Python/example_controllers/vr/oculus_touch_axis_listener.py
+++ b/Python/example_controllers/vr/oculus_touch_axis_listener.py
@@ -21,8 +21,8 @@ class OculusTouchAxisListener(Controller):
         # Move the robot joints with the control sticks.
         self.vr.listen_to_axis(is_left=True, function=self.left_axis)
         self.vr.listen_to_axis(is_left=False, function=self.right_axis)
-        # Quit when the left trigger button is pressed.
-        self.vr.listen_to_button(button=OculusTouchButton.trigger_button, is_left=True, function=self.quit)
+        # Quit when the left control stick is clicked.
+        self.vr.listen_to_button(button=OculusTouchButton.primary_2d_axis_click, is_left=True, function=self.quit)
         self.add_ons.extend([self.robot, self.vr])
         self.done: bool = False
 

--- a/Python/example_controllers/vr/oculus_touch_button_listener.py
+++ b/Python/example_controllers/vr/oculus_touch_button_listener.py
@@ -17,10 +17,10 @@ class OculusTouchButtonListener(Controller):
         self.simulation_done = False
         self.trial_done = False
         self.vr = OculusTouch()
-        # Quit when the left trigger button is pressed.
-        self.vr.listen_to_button(button=OculusTouchButton.trigger_button, is_left=True, function=self.quit)
-        # End the trial when the right trigger button is pressed.
-        self.vr.listen_to_button(button=OculusTouchButton.trigger_button, is_left=False, function=self.end_trial)
+        # Quit when the left control stick is clicked.
+        self.vr.listen_to_button(button=OculusTouchButton.primary_2d_axis_click, is_left=True, function=self.quit)
+        # End the trial when the Y button is pressed.
+        self.vr.listen_to_button(button=OculusTouchButton.secondary_button, is_left=True, function=self.end_trial)
         self.add_ons.extend([self.vr])
         self.communicate(TDWUtils.create_empty_room(12, 12))
 

--- a/Python/example_controllers/vr/oculus_touch_composite_object.py
+++ b/Python/example_controllers/vr/oculus_touch_composite_object.py
@@ -15,8 +15,8 @@ class OculusTouchCompositeObject(Controller):
         self.done = False
         # Add the VR rig.
         self.vr = OculusTouch(human_hands=False, output_data=True, attach_avatar=True, set_graspable=False)
-        # Quit when the left trigger button is pressed.
-        self.vr.listen_to_button(button=OculusTouchButton.trigger_button, is_left=True, function=self.quit)
+        # Quit when the left control stick is clicked.
+        self.vr.listen_to_button(button=OculusTouchButton.primary_2d_axis_click, is_left=True, function=self.quit)
         self.add_ons.append(self.vr)
 
     def run(self) -> None:

--- a/Python/example_controllers/vr/oculus_touch_image_capture.py
+++ b/Python/example_controllers/vr/oculus_touch_image_capture.py
@@ -20,8 +20,8 @@ class OculusTouchImageCapture(Controller):
         self.done = False
         # Add the VR rig.
         self.vr = OculusTouch(human_hands=False, output_data=True, attach_avatar=True, set_graspable=False)
-        # Quit when the left trigger button is pressed.
-        self.vr.listen_to_button(button=OculusTouchButton.trigger_button, is_left=True, function=self.quit)
+        # Quit when the left control stick is clicked.
+        self.vr.listen_to_button(button=OculusTouchButton.primary_2d_axis_click, is_left=True, function=self.quit)
         # Enable image capture.
         self.image_capture = ImageCapture(avatar_ids=[OculusTouch.AVATAR_ID], pass_masks=["_id"],
                                           path=EXAMPLE_CONTROLLER_OUTPUT_PATH.joinpath("vr_observed_objects"))

--- a/Python/example_controllers/vr/oculus_touch_loading_screen.py
+++ b/Python/example_controllers/vr/oculus_touch_loading_screen.py
@@ -17,10 +17,10 @@ class LoadingScreen(Controller):
         # Add a VR rig.
         self.vr: OculusTouch = OculusTouch()
         self.done: bool = False
-        # Quit when the left trigger button is pressed.
-        self.vr.listen_to_button(button=OculusTouchButton.trigger_button, is_left=True, function=self.quit)
-        # Go to the next scene when the right trigger button is pressed.
-        self.vr.listen_to_button(button=OculusTouchButton.trigger_button, is_left=False, function=self.next_trial)
+        # Quit when the left control stick is clicked.
+        self.vr.listen_to_button(button=OculusTouchButton.primary_2d_axis_click, is_left=True, function=self.quit)
+        # Go to the next scene when the Y button is pressed.
+        self.vr.listen_to_button(button=OculusTouchButton.secondary_button, is_left=True, function=self.next_trial)
         self.add_ons.append(self.vr)
         # Load the first scene.
         self.next_trial()

--- a/Python/example_controllers/vr/oculus_touch_output_data.py
+++ b/Python/example_controllers/vr/oculus_touch_output_data.py
@@ -14,8 +14,8 @@ class OculusTouchOutputData(Controller):
         self.done = False
 
         self.vr = OculusTouch(human_hands=False, output_data=True)
-        # Quit when the left trigger button is pressed.
-        self.vr.listen_to_button(button=OculusTouchButton.trigger_button, is_left=True, function=self.quit)
+        # Quit when the left control stick is clicked.
+        self.vr.listen_to_button(button=OculusTouchButton.primary_2d_axis_click, is_left=True, function=self.quit)
         self.add_ons.extend([self.vr])
 
     def run(self) -> None:

--- a/Python/example_controllers/vr/oculus_touch_py_impact.py
+++ b/Python/example_controllers/vr/oculus_touch_py_impact.py
@@ -18,10 +18,10 @@ class OculusTouchPyImpact(Controller):
         self.simulation_done = False
         self.trial_done = False
         self.vr = OculusTouch(set_graspable=True)
-        # Quit when the left trigger button is pressed.
-        self.vr.listen_to_button(button=OculusTouchButton.trigger_button, is_left=True, function=self.quit)
-        # End the trial when the right trigger button is pressed.
-        self.vr.listen_to_button(button=OculusTouchButton.trigger_button, is_left=False, function=self.end_trial)
+        # Quit when the left control stick is clicked.
+        self.vr.listen_to_button(button=OculusTouchButton.primary_2d_axis_click, is_left=True, function=self.quit)
+        # End the trial when the Y button is pressed.
+        self.vr.listen_to_button(button=OculusTouchButton.secondary_button, is_left=True, function=self.end_trial)
         # Enable PyImpact.
         self.py_impact = PyImpact()
         self.add_ons.extend([self.vr, self.py_impact])


### PR DESCRIPTION
### Example Controllers

- Standardized the Oculus Touch input mapping in all examples in `vr/`: Click the left control stick to quit and press Y for a new trial/scene.

### Documentation

#### Modified Documentation

| Document                     | Modification                                                 |
| ---------------------------- | ------------------------------------------------------------ |
| `lessons/vr/oculus_touch.md` | Fixed the example code to standardize Oculus Touch input mapping: Click the left control stick to quit and press Y for a new trial/scene. |