### PR TITLE
Replicant arrived_at

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -34,6 +34,7 @@ To upgrade from TDW v1.9 to v1.10, read [this guide](upgrade_guides/v1.10_to_v1.
 - Fixed: At speeds greater than 60 FPS, the Replicant will appear move its arms and head much slower than its animations. This is due to arm and head motion being driven by a separate system. Now, the `duration` parameter of these actions is scaled via optional parameters, resulting in much more even motions. The value of these parameters defaults to True; if False, `duration` won't be scaled.
   - Added optional parameter `scale_reset_arms_duration` to `move_by()` and `move_to()`.
   - Added optional parameter `scale_duration` to `reach_for()`, `reset_arm()`, `look_at()`, and `reset_head()`.
+- Fixed: The `arrived_at` parameter in `replicant.move_by()` and `replicant.move_to()` sometimes doesn't get applied when checking if the Replicant arrived at the target.
 
 ### Documentation
 

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from pathlib import Path
 import re
 
-__version__ = "1.11.3.0"
+__version__ = "1.11.3.1"
 readme_path = Path('../README.md')
 if readme_path.exists():
     long_description = readme_path.read_text(encoding='utf-8')

--- a/Python/tdw/output_data.py
+++ b/Python/tdw/output_data.py
@@ -844,7 +844,7 @@ class Containment(OutputData):
     def get_tag(self) -> ContainerTag:
         return ContainerTag(self.data.Tag())
 
-    def get_overlap_ids(self) -> np.array:
+    def get_overlap_ids(self) -> np.ndarray:
         return self.data.OverlapIdsAsNumpy()
 
     def get_env(self) -> bool:

--- a/Python/tdw/replicant/actions/move_by.py
+++ b/Python/tdw/replicant/actions/move_by.py
@@ -134,7 +134,7 @@ class MoveBy(Animate):
             distance_to_target = np.linalg.norm(dynamic.transform.position - self._destination)
             distance_traversed = np.linalg.norm(dynamic.transform.position - self._initial_position)
             # We arrived at the target.
-            if distance_to_target < self.arrived_at or distance_traversed > abs(self.distance):
+            if distance_to_target < self.arrived_at or distance_traversed > abs(self.distance) - self.arrived_at:
                 self.status = ActionStatus.success
             # Stop walking if there is a collision.
             elif len(dynamic.get_collision_enters(collision_detection=self.collision_detection)) > 0:


### PR DESCRIPTION
### `tdw` module

- Fixed: The `arrived_at` parameter in `replicant.move_by()` and `replicant.move_to()` sometimes doesn't get applied when checking if the Replicant arrived at the target.