### PR TITLE
Removed all __future__ imports

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -6,6 +6,10 @@ To upgrade from TDW v1.9 to v1.10, read [this guide](upgrade_guides/v1.10_to_v1.
 
 ## v1.11.8
 
+### `tdw` module
+
+- Fixed: Replicant doesn't work in newer versions of Python because it imports `annotations` from `__future__`. This import has been removed.
+
 ### Build
 
 - Fixed: Visual effect audio doesn't work.

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from pathlib import Path
 import re
 
-__version__ = "1.11.8.1"
+__version__ = "1.11.8.2"
 readme_path = Path('../README.md')
 if readme_path.exists():
     long_description = readme_path.read_text(encoding='utf-8')

--- a/Python/tdw/add_ons/replicant.py
+++ b/Python/tdw/add_ons/replicant.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from typing import List, Optional, Dict, Union
 from copy import deepcopy
 import numpy as np

--- a/Python/tdw/replicant/actions/animate.py
+++ b/Python/tdw/replicant/actions/animate.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from typing import List, Optional
 from tdw.replicant.actions.action import Action
 from tdw.replicant.action_status import ActionStatus

--- a/Python/tdw/replicant/actions/ik_motion.py
+++ b/Python/tdw/replicant/actions/ik_motion.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from typing import List
 from abc import ABC
 from tdw.replicant.actions.action import Action

--- a/Python/tdw/replicant/actions/move_by.py
+++ b/Python/tdw/replicant/actions/move_by.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from typing import Dict, List, Optional
 import numpy as np
 from tdw.tdw_utils import TDWUtils

--- a/Python/tdw/replicant/actions/move_to.py
+++ b/Python/tdw/replicant/actions/move_to.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from typing import Union, Dict, List, Optional
 import numpy as np
 from tdw.tdw_utils import TDWUtils

--- a/Python/tdw/replicant/actions/reach_for.py
+++ b/Python/tdw/replicant/actions/reach_for.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from typing import List, Dict, Union, Optional
 import numpy as np
 from tdw.tdw_utils import TDWUtils


### PR DESCRIPTION
### `tdw` module

- Fixed: Replicant doesn't work in newer versions of Python because it imports `annotations` from `__future__`. This import has been removed.