### PR TITLE
Fixed point cloud reshaping

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -8,6 +8,7 @@ To upgrade from TDW v1.9 to v1.10, read [this guide](upgrade_guides/v1.10_to_v1.
 
 ### `tdw` module
 
+- Fixed: Point clouds reshape to `(3, width, height)` instead of `(3, height, width)`
 - Fixed: `FloorplanFlood` doesn't add the given scene's list flood effect.
 - Fixed: `QuaternionUtils.euler_angles_to_quaternion(euler)` and `QuaternionUtils.quaternion_to_euler_angles(quaternion)` return incorrect values.
 - (Backend) Fixed the type hinting of `QuaternionUtils` (np.ndarray instead of np.array).

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from pathlib import Path
 import re
 
-__version__ = "1.11.11.1"
+__version__ = "1.11.11.2"
 readme_path = Path('../README.md')
 if readme_path.exists():
     long_description = readme_path.read_text(encoding='utf-8')

--- a/Python/tdw/tdw_utils.py
+++ b/Python/tdw/tdw_utils.py
@@ -493,8 +493,8 @@ class TDWUtils:
         points_in_cam = np.multiply(TDWUtils.__CAM_TO_IMG_MAT, depth.reshape(-1))
         points_in_cam = np.concatenate((points_in_cam, np.ones((1, points_in_cam.shape[1]))), axis=0)
         points_in_world = np.dot(camera_matrix, points_in_cam)
-        points_in_world = points_in_world[:3, :].reshape(3, TDWUtils.__WIDTH, TDWUtils.__HEIGHT)
-        points_in_cam = points_in_cam[:3, :].reshape(3, TDWUtils.__WIDTH, TDWUtils.__HEIGHT)
+        points_in_world = points_in_world[:3, :].reshape(3, TDWUtils.__HEIGHT, TDWUtils.__WIDTH)
+        points_in_cam = points_in_cam[:3, :].reshape(3, TDWUtils.__HEIGHT, TDWUtils.__WIDTH)
         if filename is not None:
             f = open(filename, 'w')
             for i in range(points_in_world.shape[1]):


### PR DESCRIPTION
### `tdw` module

- Fixed: Point clouds reshape to `(3, width, height)` instead of `(3, height, width)`