### PR TITLE
Fixed: Replicant sometimes glitches if it tries to grasp a container

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -6,6 +6,10 @@ To upgrade from TDW v1.10 to v1.11, read [this guide](upgrade_guides/v1.10_to_v1
 
 ## v1.11.12
 
+### `tdw` module
+
+- Fixed: Replicant sometimes glitches if it tries to grasp a container (the container tries to parent the Replicant to itself rather than the other way around).
+
 ### Build
 
 - Fixed: NullReferenceException if `replicant.reset()` is called while the Replicant is holding an object.

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from pathlib import Path
 import re
 
-__version__ = "1.11.12.0"
+__version__ = "1.11.12.1"
 readme_path = Path('../README.md')
 if readme_path.exists():
     long_description = readme_path.read_text(encoding='utf-8')


### PR DESCRIPTION
### `tdw` module

- Fixed: Replicant sometimes glitches if it tries to grasp a container (the container tries to parent the Replicant to itself rather than the other way around).