### PR TITLE
Added: EmptyObjectManager

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -9,6 +9,7 @@ To upgrade from TDW v1.10 to v1.11, read [this guide](upgrade_guides/v1.10_to_v1
 ### `tdw` module
 
 - Fixed numpy array type hinting in TDWUtils.
+- Added: `EmptyObjectManager`. Add empty objects and track their positions.
 
 ### Build
 
@@ -18,6 +19,19 @@ To upgrade from TDW v1.10 to v1.11, read [this guide](upgrade_guides/v1.10_to_v1
 ### Model Library
 
 - Added affordance points to all models in `models_flex.json`
+
+### Example Controllers
+
+- Added: `non_physics/empty_objects.py`
+
+### Documentation
+
+#### New Documentation
+
+| Document                                 | Description                         |
+| ---------------------------------------- | ----------------------------------- |
+| `lessons/non_physics/empty_objects.md`   | Lesson for the `EmptyObjectManager` |
+| `python/add_ons/empty_object_manager.md` | API for the `EmptyObjectManager`.   |
 
 ## v1.11.12
 

--- a/Documentation/lessons/non_physics/empty_objects.md
+++ b/Documentation/lessons/non_physics/empty_objects.md
@@ -1,0 +1,85 @@
+##### Non-physics objects
+
+# Empty objects
+
+An empty object is a transform point attached to a [TDW object](../core_concepts/objects.md).  An empty object has a position and rotation. When the parent object moves or rotates, the empty object moves or rotates relative to the parent object. An empty object doesn't have a visual mesh, colliders, mass, etc. It won't respond to any physics events independent of its parent object's physics events. TDW objects may have any number of child empty objects.
+
+In most cases, empty objects are meant to be handled in add-on internal code. For example [Replicants try to reach for objects at affordance points](../replicants/arm_articulation.md); these affordance points are actually empty objects that have been automatically added to the TDW objects using model record metadata.
+
+## The `EmptyObjectManager` add-on
+
+You can also add your own empty objects. Any time you need a point in space to continuously move and rotate relative to an object, you should use empty objects.
+
+The best way to add empty objects and get their positions is by using an [`EmptyObjectManager`](../../python/add_ons/empty_object_manager.md). This add-on has an `empty_object_positions` parameter in the constructor in which you can set your empty object positions per object (in addition to the empty objects that TDW will automatically set from model record metadata). 
+
+The positions of each empty object are stored in `empty_object_manager.empty_objects`, a dictionary. Key = Object ID. Value = A list of positions as numpy arrays. The `empty_objects` dictionary includes the empty objects you added via the `empty_object_positions` parameter plus any empty objects added automatically by TDW.
+
+To reset `EmptyObjectManager` for a new scene, call: `empty_object_manager.reset(empty_object_positions)`.
+
+This is a minimal example:
+
+```python
+from tdw.add_ons.empty_object_manager import EmptyObjectManager
+from tdw.controller import Controller
+from tdw.tdw_utils import TDWUtils
+
+c = Controller()
+object_id = 0
+empty_object_manager = EmptyObjectManager(empty_object_positions={object_id: [{"x": 0, "y": 5, "z": 0}]})
+c.add_ons.append(empty_object_manager)
+c.communicate([TDWUtils.create_empty_room(12, 12),
+               Controller.get_add_object(model_name="cube",
+                                         object_id=object_id,
+                                         library="models_flex.json",
+                                         position={"x": 0, "y": 0.5, "z": 0},
+                                         rotation={"x": 70, "y": 0, "z": 0})])
+for i in range(10):
+    c.communicate([])
+    print(empty_object_manager.empty_objects[object_id][0])
+c.communicate({"$type": "terminate"})
+```
+
+Output:
+
+```
+[0.        2.2071574 4.6984634]
+[0.        2.2042146 4.6984634]
+[0.        2.2002904 4.6984634]
+[0.        2.1953855 4.6984634]
+[0.        2.1894994 4.6984634]
+[0.        2.1826324 4.6984634]
+[1.2850297e-03 2.1690733e+00 4.7039351e+00]
+[1.2141104e-03 2.1516466e+00 4.7120643e+00]
+[7.0444454e-04 2.1317329e+00 4.7214184e+00]
+[3.3666918e-04 2.1096809e+00 4.7316799e+00]
+```
+
+## Low-level description
+
+`EmptyObjectManager` initializes by sending [`send_dynamic_static_objects`](../../api/command_api.md#send_static_objects) and [`send_dynamic_empty_objects`](../../api/command_api.md#send_dynamic_empty_objects). On the first `communicate()` call, the add-on receives [`StaticEmptyObjects`](../../api/output_data.md#StaticEmptyObjects). On every `communicate()` call, the add-on receives [`DynamicEmptyObjects`](../../api/output_data.md#DynamicEmptyObjects).
+
+***
+
+**This is the last document in the "Non-physics objects" tutorial.**
+
+[Return to the README](../../../README.md)
+
+***
+
+Example controllers:
+
+- [empty_objects.py](https://github.com/threedworld-mit/tdw/blob/master/Python/example_controllers/non_physics/empty_objects.py)  Add an empty object to a cube and print its position per communicate() call.
+
+Python API:
+
+- [`EmptyObjectManager`](../../python/add_ons/empty_object_manager.md)
+
+Command API:
+
+- [`send_dynamic_empty_objects`](../../api/command_api.md#send_dynamic_empty_objects)
+- [`send_dynamic_static_objects`](../../api/command_api.md#send_static_objects)
+
+Output Data:
+
+- [`DynamicEmptyObjects`](../../api/output_data.md#DynamicEmptyObjects)
+- [`StaticEmptyObjects`](../../api/output_data.md#StaticEmptyObjects)

--- a/Documentation/lessons/non_physics/floorplan_flood.md
+++ b/Documentation/lessons/non_physics/floorplan_flood.md
@@ -95,7 +95,7 @@ The `FloorplanFlood` add-on uses custom-sized flood objects that must be added a
 
 ***
 
-**This is the last document in the "Non-physics objects" tutorial.**
+**Next: [Empty objects](empty_objects.md)**
 
 [Return to the README](../../../README.md)
 

--- a/Documentation/python/add_ons/empty_object_manager.md
+++ b/Documentation/python/add_ons/empty_object_manager.md
@@ -1,0 +1,72 @@
+# EmptyObjectManager
+
+`from tdw.add_ons.empty_object_manager import EmptyObjectManager`
+
+A manager add-on for empty objects.
+
+In TDW, empty objects are typically used to set affordance points on objects, such as the handle of a coffee mug. These affordance points can then be targeted by agents.
+
+This add-on allows you to add your own empty objects to TDW objects and track their positions per `communicate()` call.
+
+***
+
+## Fields
+
+- `empty_objects` The positions of the empty objects. This is updated after every `communicate()` call. Key = Parent object ID. Value = Dictionary. Key = Empty object ID. Value = Empty object position as a numpy array, in world space coordinates.
+
+- `commands` These commands will be appended to the commands of the next `communicate()` call.
+
+- `initialized` If True, this module has been initialized.
+
+***
+
+## Functions
+
+#### \_\_init\_\_
+
+**`EmptyObjectManager(empty_object_positions)`**
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| empty_object_positions |  Dict[int, List[dict] |  | A dictionary of empty object positions. Key = Parent object ID. Value = Positions relative to the parent object's bottom-center. Can be None. |
+
+#### get_initialization_commands
+
+**`self.get_initialization_commands()`**
+
+This function gets called exactly once per add-on. To re-initialize, set `self.initialized = False`.
+
+_Returns:_  A list of commands that will initialize this add-on.
+
+#### on_send
+
+**`self.on_send(resp)`**
+
+This is called within `Controller.communicate(commands)` after commands are sent to the build and a response is received.
+
+Use this function to send commands to the build on the next `Controller.communicate(commands)` call, given the `resp` response.
+Any commands in the `self.commands` list will be sent on the *next* `Controller.communicate(commands)` call.
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| resp |  List[bytes] |  | The response from the build. |
+
+#### before_send
+
+**`self.before_send(commands)`**
+
+This is called within `Controller.communicate(commands)` before sending commands to the build. By default, this function doesn't do anything.
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| commands |  List[dict] |  | The commands that are about to be sent to the build. |
+
+#### reset
+
+**`self.reset(empty_object_positions)`**
+
+Reset the add-on.
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| empty_object_positions |  Dict[int, List[dict] |  | A dictionary of empty object positions. Key = Parent object ID. Value = Positions relative to the parent object's bottom-center. Can be None. |

--- a/Python/example_controllers/non_physics/empty_objects.py
+++ b/Python/example_controllers/non_physics/empty_objects.py
@@ -1,0 +1,22 @@
+from tdw.add_ons.empty_object_manager import EmptyObjectManager
+from tdw.controller import Controller
+from tdw.tdw_utils import TDWUtils
+
+"""
+Add an empty object to a cube and print its position per communicate() call.
+"""
+
+c = Controller()
+object_id = 0
+empty_object_manager = EmptyObjectManager(empty_object_positions={object_id: [{"x": 0, "y": 5, "z": 0}]})
+c.add_ons.append(empty_object_manager)
+c.communicate([TDWUtils.create_empty_room(12, 12),
+               Controller.get_add_object(model_name="cube",
+                                         object_id=object_id,
+                                         library="models_flex.json",
+                                         position={"x": 0, "y": 0.5, "z": 0},
+                                         rotation={"x": 70, "y": 0, "z": 0})])
+for i in range(10):
+    c.communicate([])
+    print(empty_object_manager.empty_objects[object_id][0])
+c.communicate({"$type": "terminate"})

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from pathlib import Path
 import re
 
-__version__ = "1.11.13.1"
+__version__ = "1.11.13.2"
 readme_path = Path('../README.md')
 if readme_path.exists():
     long_description = readme_path.read_text(encoding='utf-8')

--- a/Python/tdw/add_ons/empty_object_manager.py
+++ b/Python/tdw/add_ons/empty_object_manager.py
@@ -1,0 +1,89 @@
+from typing import Dict, List, Tuple
+import numpy as np
+from tdw.add_ons.add_on import AddOn
+from tdw.output_data import OutputData, StaticEmptyObjects, DynamicEmptyObjects
+
+
+class EmptyObjectManager(AddOn):
+    """
+    A manager add-on for empty objects.
+
+    In TDW, empty objects are typically used to set affordance points on objects, such as the handle of a coffee mug. These affordance points can then be targeted by agents.
+
+    This add-on allows you to add your own empty objects to TDW objects and track their positions per `communicate()` call.
+    """
+
+    def __init__(self, empty_object_positions: Dict[int, List[dict]] = None):
+        """
+        :param empty_object_positions: A dictionary of empty object positions. Key = Parent object ID. Value = Positions relative to the parent object's bottom-center. Can be None.
+        """
+
+        super().__init__()
+        """:field
+        The positions of the empty objects. This is updated after every `communicate()` call. Key = Parent object ID. Value = Dictionary. Key = Empty object ID. Value = Empty object position as a numpy array, in world space coordinates.
+        """
+        self.empty_objects: Dict[int, Dict[int, np.ndarray]] = dict()
+        # The positions of empty objects that the user is manually adding.
+        self._empty_object_positions: Dict[int, List[dict]] = dict()
+        if empty_object_positions is not None:
+            self._empty_object_positions.update({k: v for k, v in empty_object_positions.items()})
+        # A mapping of output data indices to object/empty object IDs.
+        self._empty_object_indices: Dict[int, Tuple[int, int]] = dict()
+        # A flag for caching static data.
+        self._got_static_data: bool = False
+
+    def get_initialization_commands(self) -> List[dict]:
+        self._got_static_data = False
+        commands = []
+        for object_id in self._empty_object_positions:
+            for i in range(len(self._empty_object_positions[object_id])):
+                commands.append({"$type": "attach_empty_object",
+                                 "position": self._empty_object_positions[object_id][i],
+                                 "empty_object_id": i,
+                                 "id": object_id})
+        commands.extend([{"$type": "send_static_empty_objects",
+                         "frequency": "once"},
+                         {"$type": "send_dynamic_empty_objects",
+                         "frequency": "always"}])
+        return commands
+
+    def on_send(self, resp: List[bytes]) -> None:
+        if not self._got_static_data:
+            for i in range(len(resp) - 1):
+                r_id = OutputData.get_data_type_id(resp[i])
+                if r_id == "stem":
+                    static_empty_objects = StaticEmptyObjects(resp[i])
+                    for j in range(static_empty_objects.get_num()):
+                        object_id = static_empty_objects.get_object_id(j)
+                        empty_object_id = static_empty_objects.get_empty_object_id(j)
+                        # Remember this object ID.
+                        if object_id not in self.empty_objects:
+                            self.empty_objects[object_id] = dict()
+                        # Remember the indices.
+                        self._empty_object_indices[j] = (object_id, empty_object_id)
+                    break
+                self._got_static_data = True
+        for i in range(len(resp) - 1):
+            r_id = OutputData.get_data_type_id(resp[i])
+            if r_id == "dyem":
+                dynamic_empty_objects = DynamicEmptyObjects(resp[i])
+                for j in range(dynamic_empty_objects.get_num()):
+                    # Convert the index to object IDs.
+                    ids = self._empty_object_indices[j]
+                    # Store the position.
+                    self.empty_objects[ids[0]][ids[1]] = dynamic_empty_objects.get_position(j)
+
+    def reset(self, empty_object_positions: Dict[int, List[dict]] = None) -> None:
+        """
+        Reset the add-on.
+
+        :param empty_object_positions: A dictionary of empty object positions. Key = Parent object ID. Value = Positions relative to the parent object's bottom-center. Can be None.
+        """
+
+        self.empty_objects.clear()
+        self.initialized = False
+        self._got_static_data = False
+        self._empty_object_positions.clear()
+        self._empty_object_indices.clear()
+        if empty_object_positions is not None:
+            self._empty_object_positions.update({k: v for k, v in empty_object_positions.items()})

--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ High-level API: [tdw_physics](https://github.com/alters-mit/tdw_physics)
 6. [Compass rose](Documentation/lessons/non_physics/compass_rose.md)
 7. [Visual Effects](Documentation/lessons/non_physics/visual_effects.md)
 8. [The `FloorplanFlood` add-on](Documentation/lessons/non_physics/floorplan_flood.md)
+9. [Empty objects](Documentation/lessons/non_physics/empty_objects.md)
 
 ## 15. Misc. remote server topics
 
@@ -319,6 +320,7 @@ High-level API: [tdw_physics](https://github.com/alters-mit/tdw_physics)
 - [CompositeObjectManager](Documentation/python/add_ons/composite_object_manager.md)
 - [ContainerManager](Documentation/python/add_ons/container_manager.md)
 - [EmbodiedAvatar](Documentation/python/add_ons/embodied_avatar.md)
+- [EmptyObjectManager](Documentation/python/add_ons/empty_object_manager.md)
 - [FirstPersonAvatar](Documentation/python/add_ons/first_person_avatar.md)
 - [Floorplan](Documentation/python/add_ons/floorplan.md)
 - [FloorplanFlood](Documentation/python/add_ons/floorplan_flood.md)


### PR DESCRIPTION
### `tdw` module

- Added: `EmptyObjectManager`. Add empty objects and track their positions.

### Example Controllers

- Added: `non_physics/empty_objects.py`

### Documentation

#### New Documentation

| Document                                 | Description                         |
| ---------------------------------------- | ----------------------------------- |
| `lessons/non_physics/empty_objects.md`   | Lesson for the `EmptyObjectManager` |
| `python/add_ons/empty_object_manager.md` | API for the `EmptyObjectManager`.   |