### PR TITLE
X11 forwarding documentation

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -19,6 +19,21 @@ To upgrade from TDW v1.10 to v1.11, read [this guide](upgrade_guides/v1.10_to_v1
 
 - Added affordance points to all models in `models_flex.json`
 
+### Documentation
+
+#### New Documentation
+
+| Document                           | Description                                  |
+| ---------------------------------- | -------------------------------------------- |
+| `lessons/remote/overview.md`       | Overview of documentation for Linux servers. |
+| `lessons/remote/x11_forwarding.md` | X11 forwarding.                              |
+
+#### Modified Documentation
+
+| Document    | Modification                                                 |
+| ----------- | ------------------------------------------------------------ |
+| `README.md` | Moved the remote server documentation to be just below the setup section. |
+
 ## v1.11.12
 
 ### `tdw` module

--- a/Documentation/lessons/remote/launch_build.md
+++ b/Documentation/lessons/remote/launch_build.md
@@ -1,8 +1,8 @@
-##### Misc. remote server topics
+##### How to run TDW on a Linux server
 
 # Launch a TDW build on a remote server from a personal computer
 
-## Step 1: Launch binary_manager.py on the remote server
+## Step 1: Launch remote_build_launcher.py on the remote server
 
 [binary_manager.py](https://github.com/threedworld-mit/tdw/blob/master/Python/binary_manager.py) can be used to launch and manage TDW builds on a remote server.
 

--- a/Documentation/lessons/remote/overview.md
+++ b/Documentation/lessons/remote/overview.md
@@ -1,0 +1,17 @@
+##### How to run TDW on a Linux server
+
+# Overview
+
+This lesson covers miscellaneous Linux server topics. For instructions on how to install TDW on a remote Linux server and/or in a Docker container, read [the TDW installation documentation](../core_concepts.md).
+
+- [Launch a TDW build on a remote server from a personal computer](launch_build.md)
+- [Remote rendering with xpra](xpra.md) 
+- [X11 forwarding](x11_forwarding.md)
+
+***
+
+**Next: [Launch a TDW build on a remote server from a personal computer](launch_build.md).**
+
+[Return to the README](../../../README.md)
+
+***

--- a/Documentation/lessons/remote/x11_forwarding.md
+++ b/Documentation/lessons/remote/x11_forwarding.md
@@ -1,0 +1,43 @@
+##### How to run TDW on a Linux server
+
+# X11 fowarding
+
+Follow these steps to enable X11 forwarding from a local machine. 
+
+## OS X
+
+This has been tested on macOs13.3.1:
+
+1. Install XQuartz
+2. Open a terminal and run `ssh -X username@serverdomain`
+3. In the same terminal, `echo $DISPLAY` to ensure that there is a valid display.
+4. In the same terminal, open a tmux session on the server and launch the build: `./TDW.x86_64 -port=1071`, notice that you don’t need to specify the display number because it has been set automatically. You should be able to see a TDW window pops up on your local machine.
+5. Open a second terminal and run `ssh -X username@serverdomain`
+6. In the second terminal, open a tmux session on the server and run this example controller: 
+
+```python
+from tdw.controller import Controller
+
+c = Controller(launch_build=False) 
+print("Hello world!")
+c.communicate({"$type": "terminate"})
+```
+
+Result: The console prints `Hello world!` and exits.
+
+If you intend to spawn many jobs on the server,  this method is not ideal because it will span many windows on your local machine. [Try this instead.](https://stackoverflow.com/a/8961649)
+
+## Windows
+
+X11 forwarding hasn't been tested on Windows yet. If you know how to set up X11 forwarding on Windows, please let us know.
+
+## Linux
+
+X11 forwarding hasn't been tested on Linux yet. If you know how to set up X11 forwarding on Linux, please let us know.
+
+
+***
+
+**This is the last document in the "Misc. remote server topics" tutorial.**
+
+[Return to the README](../../../README.md)

--- a/Documentation/lessons/remote/xpra.md
+++ b/Documentation/lessons/remote/xpra.md
@@ -1,4 +1,4 @@
-##### Misc. remote server topics
+##### How to run TDW on a Linux server
 
 # Remote rendering with xpra
 
@@ -44,6 +44,8 @@ On newer Nvidia driver versions (>440), applications may be locked at 1 fps. For
 ***
 
 **This is the last document in the "Misc. remote server topics" tutorial.**
+
+**Next: [X11 forwarding](x11_forwarding.md).**
 
 [Return to the README](../../../README.md)
 

--- a/Documentation/lessons/setup/install.md
+++ b/Documentation/lessons/setup/install.md
@@ -45,6 +45,8 @@ c.communicate({"$type": "terminate"})
 
 ## Install TDW on a remote Linux server
 
+**[For more in-depth information on how to run TDW on a remote Linux server, [read this](../remote/overview.md).**
+
 #### Install NVIDIA and X on your server
 
 1. Download and install latest NVIDIA drivers for the machine

--- a/README.md
+++ b/README.md
@@ -14,8 +14,17 @@
 
 ## Setup
 
+### 1.1 Installation (Read this first!)
+
 1. [Install TDW](Documentation/lessons/setup/install.md)
 3. [Upgrade TDW](Documentation/lessons/setup/upgrade.md)
+
+### 1.2 How to run TDW on a Linux server
+
+1. [Overview](Documentation/lessons/remote/overview.md)
+2. [Launch a TDW build on a remote server from a personal computer](Documentation/lessons/remote/launch_build.md)
+3. [Remote rendering with xpra](Documentation/lessons/remote/xpra.md)
+4. [X11 forwarding](Documentation/lessons/remote/x11_forwarding.md)
 
 ## Core Concepts
 
@@ -275,12 +284,7 @@ High-level API: [tdw_physics](https://github.com/alters-mit/tdw_physics)
 7. [Visual Effects](Documentation/lessons/non_physics/visual_effects.md)
 8. [The `FloorplanFlood` add-on](Documentation/lessons/non_physics/floorplan_flood.md)
 
-## 15. Misc. remote server topics
-
-1. [Launch a TDW build on a remote server from a personal computer](Documentation/lessons/remote/launch_build.md)
-2. [Remote rendering with xpra](Documentation/lessons/remote/xpra.md)
-
-## 16. Misc. other topics
+## 15. Misc. other topics
 
 1. [C# source code](Documentation/lessons/misc/c_sharp_sources.md)
 2. [Freezing your code](Documentation/lessons/misc/freeze.md)


### PR DESCRIPTION
### Documentation

#### New Documentation

| Document                           | Description                                  |
| ---------------------------------- | -------------------------------------------- |
| `lessons/remote/overview.md`       | Overview of documentation for Linux servers. |
| `lessons/remote/x11_forwarding.md` | X11 forwarding.                              |

#### Modified Documentation

| Document    | Modification                                                 |
| ----------- | ------------------------------------------------------------ |
| `README.md` | Moved the remote server documentation to be just below the setup section. |