### PR TITLE
Type aliases

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -31,6 +31,7 @@ To upgrade from TDW v1.10 to v1.11, read [this guide](upgrade_guides/v1.10_to_v1
 - (Backend) Added abstract class `AgentDynamic`. `ReplicantDynamic` and `DroneDynamic` are now subclasses of `AgentDynamic`, as is the new `VehicleDynamic`.
 - Fixed: If a Replicant starts a new action while an animation is playing (i.e. `animate(animation)`, `move_by(distance)`, or `move_to(target)`), the animation doesn't stop.
 - (Backend) Added `tdw.type_aliases` which contains aliases for commonly used types.
+- (Backend) Replaced type hinting throughout `tdw` with type aliases. This doesn't affect any functionality but has slightly altered the API documentation.
 - Fixed: In many scripts, numpy array type hinting uses `np.array` instead of `np.ndarray`.
 
 ### Example Controllers

--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -30,6 +30,8 @@ To upgrade from TDW v1.10 to v1.11, read [this guide](upgrade_guides/v1.10_to_v1
   - Added: `VehicleLibrarian` and `VehicleRecord`
 - (Backend) Added abstract class `AgentDynamic`. `ReplicantDynamic` and `DroneDynamic` are now subclasses of `AgentDynamic`, as is the new `VehicleDynamic`.
 - Fixed: If a Replicant starts a new action while an animation is playing (i.e. `animate(animation)`, `move_by(distance)`, or `move_to(target)`), the animation doesn't stop.
+- (Backend) Added `tdw.type_aliases` which contains aliases for commonly used types.
+- Fixed: In many scripts, numpy array type hinting uses `np.array` instead of `np.ndarray`.
 
 ### Example Controllers
 
@@ -48,6 +50,7 @@ To upgrade from TDW v1.10 to v1.11, read [this guide](upgrade_guides/v1.10_to_v1
 | `python/add_ons/vehicle.md`             | `Vehicle` API          |
 | `python/vehicle/vehicle_dynamic.md`       | `VehicleDynamic` API   |
 | `python/librarian/vehicle_librarian.md` | `VehicleLibrarian` API |
+| `python/type_aliases.md` | Type aliases API |
 
 #### Modified Documentation
 

--- a/Documentation/python/add_ons/audio_initializer.md
+++ b/Documentation/python/add_ons/audio_initializer.md
@@ -64,7 +64,7 @@ The command will be sent on the next `Controller.communicate()` call.
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | path |  Union[str, Path] |  | The path to a .wav file. |
-| position |  Union[np.array, Dict[str, float] |  | The position of audio source. Can be a numpy array or x, y, z dictionary. |
+| position |  POSITION |  | The position of audio source. Can be a numpy array or x, y, z dictionary. |
 | audio_id |  int  | None | The unique ID of the audio source. If None, a random ID is generated. |
 | object_id |  int  | None | If not None, parent the audio source to this object. |
 

--- a/Documentation/python/add_ons/audio_initializer_base.md
+++ b/Documentation/python/add_ons/audio_initializer_base.md
@@ -72,6 +72,6 @@ The command will be sent on the next `Controller.communicate()` call.
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | path |  Union[str, Path] |  | The path to a .wav file. |
-| position |  Union[np.array, Dict[str, float] |  | The position of audio source. Can be a numpy array or x, y, z dictionary. |
+| position |  POSITION |  | The position of audio source. Can be a numpy array or x, y, z dictionary. |
 | audio_id |  int  | None | The unique ID of the audio source. If None, a random ID is generated. |
 | object_id |  int  | None | If not None, parent the audio source to this object. |

--- a/Documentation/python/add_ons/drone.md
+++ b/Documentation/python/add_ons/drone.md
@@ -38,15 +38,15 @@ The drone's output data, including images, is stored in [`drone.dynamic`](../dro
 
 #### \_\_init\_\_
 
-**`Drone(position, rotation)`**
+**`Drone()`**
 
-**`Drone(drone_id=0, position, rotation, name="drone", forward_speed=3, backward_speed=3, rise_speed=3, drop_speed=3, acceleration=0.3, deceleration=0.2, stability=0.1, turn_sensitivity=2, enable_lights=False, motor_on=True, image_capture=True, image_passes=None)`**
+**`Drone(drone_id=0, position=None, rotation=None, name="drone", forward_speed=3, backward_speed=3, rise_speed=3, drop_speed=3, acceleration=0.3, deceleration=0.2, stability=0.1, turn_sensitivity=2, enable_lights=False, motor_on=True, image_capture=True, image_passes=None)`**
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | drone_id |  int  | 0 | The ID of the drone. |
-| position |  Union[Dict[str, float] |  | The position of the drone as an x, y, z dictionary or numpy array. If None, defaults to `{"x": 0, "y": 0, "z": 0}`. |
-| rotation |  Union[Dict[str, float] |  | The rotation of the drone in Euler angles (degrees) as an x, y, z dictionary or numpy array. If None, defaults to `{"x": 0, "y": 0, "z": 0}`. |
+| position |  POSITION  | None | The position of the drone as an x, y, z dictionary or numpy array. If None, defaults to `{"x": 0, "y": 0, "z": 0}`. |
+| rotation |  ROTATION  | None | The rotation of the drone in Euler angles (degrees) as an x, y, z dictionary or numpy array. If None, defaults to `{"x": 0, "y": 0, "z": 0}`. |
 | name |  str  | "drone" | The name of the drone model. |
 | forward_speed |  float  | 3 | Sets the drone's max forward speed. |
 | backward_speed |  float  | 3 | Sets the drone's max backward speed. |

--- a/Documentation/python/add_ons/embodied_avatar.md
+++ b/Documentation/python/add_ons/embodied_avatar.md
@@ -136,7 +136,7 @@ Look at a target object or position.
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| target |  Union[int, Dict[str, float] |  | The target. If int: an object ID. If a dictionary or numpy array: an x, y, z position. |
+| target |  TARGET |  | The target. If int: an object ID. If a dictionary or numpy array: an x, y, z position. |
 
 #### reset_camera
 

--- a/Documentation/python/add_ons/oculus_touch.md
+++ b/Documentation/python/add_ons/oculus_touch.md
@@ -156,4 +156,4 @@ Listen for Oculus Touch controller axis events.
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | is_left |  bool |  | If True, this is the left controller. If False, this is the right controller. |
-| function |  Callable[[np.array] |  | The function to invoke when the button is pressed. This function must a single argument (a numpy array of shape `(2)`, representing (x, y) coordinates) and return None. |
+| function |  Callable[[np.ndarray] |  | The function to invoke when the button is pressed. This function must a single argument (a numpy array of shape `(2)`, representing (x, y) coordinates) and return None. |

--- a/Documentation/python/add_ons/py_impact.md
+++ b/Documentation/python/add_ons/py_impact.md
@@ -152,8 +152,8 @@ Produce sound of two colliding objects as a byte array.
 | secondary_amp |  float |  | Sound amplitude of the secondary (other) object. |
 | primary_resonance |  float |  | The resonance of the primary (target) object. |
 | secondary_resonance |  float |  | The resonance of the secondary (other) object. |
-| velocity |  np.array |  | The velocity. |
-| contact_normals |  List[np.array] |  | The collision contact normals. |
+| velocity |  np.ndarray |  | The velocity. |
+| contact_normals |  List[np.ndarray] |  | The collision contact normals. |
 | primary_mass |  float |  | The mass of the primary (target) object. |
 | secondary_mass |  float |  | The mass of the secondary (target) object. |
 
@@ -178,9 +178,9 @@ Create an impact sound, and return a valid command to play audio data in TDW.
 | secondary_amp |  float |  | Sound amplitude of the secondary (other) object. |
 | primary_resonance |  float |  | The resonance of the primary (target) object. |
 | secondary_resonance |  float |  | The resonance of the secondary (other) object. |
-| velocity |  np.array |  | The velocity. |
-| contact_points |  List[np.array] |  | The collision contact points. |
-| contact_normals |  List[np.array] |  | The collision contact normals. |
+| velocity |  np.ndarray |  | The velocity. |
+| contact_points |  List[np.ndarray] |  | The collision contact points. |
+| contact_normals |  List[np.ndarray] |  | The collision contact normals. |
 | primary_mass |  float |  | The mass of the primary (target) object. |
 | secondary_mass |  float |  | The mass of the secondary (target) object. |
 
@@ -201,9 +201,9 @@ _Returns:_  A `play_audio_data` or `play_point_source_data` command that can be 
 | secondary_amp |  float |  | Sound amplitude of the secondary (other) object. |
 | primary_resonance |  float |  | The resonance of the primary (target) object. |
 | secondary_resonance |  float |  | The resonance of the secondary (other) object. |
-| velocity |  np.array |  | The velocity. |
-| contact_points |  np.array |  | The collision contact points. |
-| contact_normals |  List[np.array] |  | The collision contact normals. |
+| velocity |  np.ndarray |  | The velocity. |
+| contact_points |  np.ndarray |  | The collision contact points. |
+| contact_normals |  List[np.ndarray] |  | The collision contact normals. |
 | primary_mass |  float |  | The mass of the primary (target) object. |
 | secondary_mass |  float |  | The mass of the secondary (target) object. |
 | scrape_material |  ScrapeMaterial |  | The [scrape material](../physics_audio/scrape_material.md). |
@@ -229,8 +229,8 @@ Create a scrape sound, and return a valid command to play audio data in TDW.
 | secondary_amp |  float |  | Sound amplitude of the secondary (other) object. |
 | primary_resonance |  float |  | The resonance of the primary (target) object. |
 | secondary_resonance |  float |  | The resonance of the secondary (other) object. |
-| velocity |  np.array |  | The velocity. |
-| contact_normals |  List[np.array] |  | The collision contact normals. |
+| velocity |  np.ndarray |  | The velocity. |
+| contact_normals |  List[np.ndarray] |  | The collision contact normals. |
 | primary_mass |  float |  | The mass of the primary (target) object. |
 | secondary_mass |  float |  | The mass of the secondary (target) object. |
 | scrape_material |  ScrapeMaterial |  | The [scrape material](../physics_audio/scrape_material.md). |

--- a/Documentation/python/add_ons/replicant.md
+++ b/Documentation/python/add_ons/replicant.md
@@ -42,15 +42,15 @@ A Replicant can walk, turn, reach for positions or objects, grasp and drop objec
 
 #### \_\_init\_\_
 
-**`Replicant(position, rotation)`**
+**`Replicant()`**
 
-**`Replicant(replicant_id=0, position, rotation, image_frequency=ImageFrequency.once, name="replicant_0", target_framerate=100)`**
+**`Replicant(replicant_id=0, position=None, rotation=None, image_frequency=ImageFrequency.once, name="replicant_0", target_framerate=100)`**
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | replicant_id |  int  | 0 | The ID of the Replicant. |
-| position |  Union[Dict[str, float] |  | The position of the Replicant as an x, y, z dictionary or numpy array. If None, defaults to `{"x": 0, "y": 0, "z": 0}`. |
-| rotation |  Union[Dict[str, float] |  | The rotation of the Replicant in Euler angles (degrees) as an x, y, z dictionary or numpy array. If None, defaults to `{"x": 0, "y": 0, "z": 0}`. |
+| position |  POSITION  | None | The position of the Replicant as an x, y, z dictionary or numpy array. If None, defaults to `{"x": 0, "y": 0, "z": 0}`. |
+| rotation |  ROTATION  | None | The rotation of the Replicant in Euler angles (degrees) as an x, y, z dictionary or numpy array. If None, defaults to `{"x": 0, "y": 0, "z": 0}`. |
 | image_frequency |  ImageFrequency  | ImageFrequency.once | An [`ImageFrequency`](../replicant/image_frequency.md) value that sets how often images are captured. |
 | name |  str  | "replicant_0" | The name of the Replicant model. |
 | target_framerate |  int  | 100 | The target framerate. It's possible to set a higher target framerate, but doing so can lead to a loss of precision in agent movement. |
@@ -83,7 +83,7 @@ This is a non-animated action, meaning that the Replicant will immediately snap 
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| target |  Union[int, Dict[str, float] |  | The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array. |
+| target |  TARGET |  | The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array. |
 
 #### move_by
 
@@ -140,7 +140,7 @@ The action can end for several reasons depending on the collision detection rule
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| target |  Union[int, Dict[str, float] |  | The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array. |
+| target |  TARGET |  | The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array. |
 | reset_arms |  bool  | True | If True, reset the arms to their neutral positions while beginning the walk cycle. |
 | reset_arms_duration |  float  | 0.25 | The speed at which the arms are reset in seconds. |
 | scale_reset_arms_duration |  bool  | True | If True, `reset_arms_duration` will be multiplied by `framerate / 60)`, ensuring smoother motions at faster-than-life simulation speeds. |
@@ -175,7 +175,7 @@ The Replicant's arm(s) will continuously over multiple `communicate()` calls mov
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| target |  Union[int, Dict[str, float] |  | The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array. |
+| target |  TARGET |  | The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array. |
 | arm |  Union[Arm, List[Arm] |  | The [`Arm`](../replicant/arm.md) value(s) that will reach for the `target` as a single value or a list. Example: `Arm.left` or `[Arm.left, Arm.right]`. |
 | absolute |  bool  | True | If True, the target position is in world space coordinates. If False, the target position is relative to the Replicant. Ignored if `target` is an int. |
 | offhand_follows |  bool  | False | If True, the offhand will follow the primary hand, meaning that it will maintain the same relative position. Ignored if `arm` is a list or `target` is an int. |
@@ -269,7 +269,7 @@ The head will continuously move over multiple `communicate()` calls until it is 
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| target |  Union[int, np.ndarray, Dict[str, float] | target | The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array. |
+| target |  TARGET | target | The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array. |
 | duration |  float  | 0.1 | The duration of the motion in seconds. |
 | scale_duration |  bool  | True | If True, `duration` will be multiplied by `framerate / 60)`, ensuring smoother motions at faster-than-life simulation speeds. |
 
@@ -358,14 +358,16 @@ Any commands in the `self.commands` list will be sent on the *next* `Controller.
 
 #### reset
 
-**`self.reset(position, rotation)`**
+**`self.reset()`**
+
+**`self.reset(position=None, rotation=None)`**
 
 Reset the Replicant. Call this when you reset the scene.
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| position |  Union[Dict[str, float] |  | The position of the Replicant as an x, y, z dictionary or numpy array. If None, defaults to `{"x": 0, "y": 0, "z": 0}`. |
-| rotation |  Union[Dict[str, float] |  | The rotation of the Replicant in Euler angles (degrees) as an x, y, z dictionary or numpy array. If None, defaults to `{"x": 0, "y": 0, "z": 0}`. |
+| position |  POSITION  | None | The position of the Replicant as an x, y, z dictionary or numpy array. If None, defaults to `{"x": 0, "y": 0, "z": 0}`. |
+| rotation |  ROTATION  | None | The rotation of the Replicant in Euler angles (degrees) as an x, y, z dictionary or numpy array. If None, defaults to `{"x": 0, "y": 0, "z": 0}`. |
 
 ***
 

--- a/Documentation/python/add_ons/resonance_audio_initializer.md
+++ b/Documentation/python/add_ons/resonance_audio_initializer.md
@@ -107,6 +107,6 @@ The command will be sent on the next `Controller.communicate()` call.
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | path |  Union[str, Path] |  | The path to a .wav file. |
-| position |  Union[np.array, Dict[str, float] |  | The position of audio source. Can be a numpy array or x, y, z dictionary. |
+| position |  POSITION |  | The position of audio source. Can be a numpy array or x, y, z dictionary. |
 | audio_id |  int  | None | The unique ID of the audio source. If None, a random ID is generated. |
 | object_id |  int  | None | If not None, parent the audio source to this object. |

--- a/Documentation/python/add_ons/robot_arm.md
+++ b/Documentation/python/add_ons/robot_arm.md
@@ -166,4 +166,4 @@ Start to reach for a target position.
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| target |  Union[Dict[str, float] |  | The target position. Can be a dictionary or a numpy array. |
+| target |  POSITION |  | The target position. Can be a dictionary or a numpy array. |

--- a/Documentation/python/add_ons/vehicle.md
+++ b/Documentation/python/add_ons/vehicle.md
@@ -36,15 +36,15 @@ The vehicle's output data, including images, is stored in [`vehicle.dynamic`](..
 
 #### \_\_init\_\_
 
-**`Vehicle(position, rotation)`**
+**`Vehicle()`**
 
-**`Vehicle(vehicle_id=0, position, rotation, name="all_terrain_vehicle", forward_speed=30, reverse_speed=12, image_capture=True, image_passes=None)`**
+**`Vehicle(vehicle_id=0, position=None, rotation=None, name="all_terrain_vehicle", forward_speed=30, reverse_speed=12, image_capture=True, image_passes=None)`**
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | vehicle_id |  int  | 0 | The ID of the vehicle. |
-| position |  Union[Dict[str, float] |  | The position of the vehicle as an x, y, z dictionary or numpy array. If None, defaults to `{"x": 0, "y": 0, "z": 0}`. |
-| rotation |  Union[Dict[str, float] |  | The rotation of the vehicle in Euler angles (degrees) as an x, y, z dictionary or numpy array. If None, defaults to `{"x": 0, "y": 0, "z": 0}`. |
+| position |  POSITION  | None | The position of the vehicle as an x, y, z dictionary or numpy array. If None, defaults to `{"x": 0, "y": 0, "z": 0}`. |
+| rotation |  ROTATION  | None | The rotation of the vehicle in Euler angles (degrees) as an x, y, z dictionary or numpy array. If None, defaults to `{"x": 0, "y": 0, "z": 0}`. |
 | name |  str  | "all_terrain_vehicle" | The name of the vehicle model. |
 | forward_speed |  float  | 30 | Sets the vehicle's max forward speed. |
 | reverse_speed |  float  | 12 | Sets the vehicle's max reverse speed. |

--- a/Documentation/python/object_data/bound.md
+++ b/Documentation/python/object_data/bound.md
@@ -32,11 +32,11 @@ Bounds data for a single object.
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| front |  np.array |  | The position of the front point. |
-| back |  np.array |  | The position of the back point. |
-| left |  np.array |  | The position of the left point. |
-| right |  np.array |  | The position of the right point. |
-| top |  np.array |  | The position of the top point. |
-| bottom |  np.array |  | The position of the bottom point. |
-| center |  np.array |  | The position of the center point. |
+| front |  np.ndarray |  | The position of the front point. |
+| back |  np.ndarray |  | The position of the back point. |
+| left |  np.ndarray |  | The position of the left point. |
+| right |  np.ndarray |  | The position of the right point. |
+| top |  np.ndarray |  | The position of the top point. |
+| bottom |  np.ndarray |  | The position of the bottom point. |
+| center |  np.ndarray |  | The position of the center point. |
 

--- a/Documentation/python/object_data/object_static.md
+++ b/Documentation/python/object_data/object_static.md
@@ -41,8 +41,8 @@ Static data for an object. This data won't change between frames.
 | name |  str |  | The name of the object. |
 | object_id |  int |  | The unique ID of the object. |
 | mass |  float |  | The mass of the object. |
-| segmentation_color |  np.array |  | The segmentation color of the object. |
-| size |  np.array |  | The size of the object. |
+| segmentation_color |  np.ndarray |  | The segmentation color of the object. |
+| size |  np.ndarray |  | The size of the object. |
 | dynamic_friction |  float |  | The dynamic friction of the object. |
 | static_friction |  float |  | The static friction of the object. |
 | bounciness |  float |  | The bounciness of the object. |

--- a/Documentation/python/object_data/rigidbody.md
+++ b/Documentation/python/object_data/rigidbody.md
@@ -24,7 +24,7 @@ Dynamic object rigidbody data. Note that this excludes *static* rigidbody data s
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| velocity |  np.array |  | The directional velocity of the object. |
-| angular_velocity |  np.array |  | The angular velocity of the object. |
+| velocity |  np.ndarray |  | The directional velocity of the object. |
+| angular_velocity |  np.ndarray |  | The angular velocity of the object. |
 | sleeping |  bool |  | If True, the object isn't moving. |
 

--- a/Documentation/python/object_data/transform.md
+++ b/Documentation/python/object_data/transform.md
@@ -24,7 +24,7 @@ Positional data for an object, robot body part, etc.
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| position |  np.array |  | The position vector of the object as a numpy array. |
-| rotation |  np.array |  | The rotation quaternion of the object as a numpy array. |
-| forward |  np.array |  | The forward directional vector of the object as a numpy array. |
+| position |  np.ndarray |  | The position vector of the object as a numpy array. |
+| rotation |  np.ndarray |  | The rotation quaternion of the object as a numpy array. |
+| forward |  np.ndarray |  | The forward directional vector of the object as a numpy array. |
 

--- a/Documentation/python/physics_audio/base64_sound.md
+++ b/Documentation/python/physics_audio/base64_sound.md
@@ -24,7 +24,7 @@ A sound encoded as a base64 string.
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| snd |  np.array |  | The sound byte array. |
+| snd |  np.ndarray |  | The sound byte array. |
 
 #### write
 

--- a/Documentation/python/physics_audio/modes.md
+++ b/Documentation/python/physics_audio/modes.md
@@ -24,9 +24,9 @@ Resonant mode properties: Frequencies, powers, and times.
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| frequencies |  np.array |  | A numpy array of mode frequencies in Hz. |
-| powers |  np.array |  | A numpy array of mode onset powers in dB re 1. |
-| decay_times |  np.array |  | A numpy array of mode decay times i.e. the time in ms it takes for each mode to decay 60dB from its onset power. |
+| frequencies |  np.ndarray |  | A numpy array of mode frequencies in Hz. |
+| powers |  np.ndarray |  | A numpy array of mode onset powers in dB re 1. |
+| decay_times |  np.ndarray |  | A numpy array of mode decay times i.e. the time in ms it takes for each mode to decay 60dB from its onset power. |
 
 #### sum_modes
 
@@ -55,8 +55,8 @@ Add together numpy arrays of different lengths by zero-padding the shorter.
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| a |  np.array |  | The first array. |
-| b |  np.array |  | The second array. |
+| a |  np.ndarray |  | The first array. |
+| b |  np.ndarray |  | The second array. |
 
 _Returns:_  The summed modes.
 

--- a/Documentation/python/replicant/actions/look_at.md
+++ b/Documentation/python/replicant/actions/look_at.md
@@ -48,7 +48,7 @@ The head will continuously move over multiple `communicate()` calls until it is 
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| target |  Union[int, np.ndarray, Dict[str, float] |  | The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array. |
+| target |  TARGET |  | The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array. |
 | duration |  float |  | The duration of the motion in seconds. |
 | scale_duration |  bool |  | If True, `duration` will be multiplied by `framerate / 60)`, ensuring smoother motions at faster-than-life simulation speeds. |
 

--- a/Documentation/python/replicant/actions/move_to.md
+++ b/Documentation/python/replicant/actions/move_to.md
@@ -54,7 +54,7 @@ The action can end for several reasons depending on the collision detection rule
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| target |  Union[int, Dict[str, float] |  | The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array. |
+| target |  TARGET |  | The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array. |
 | collision_detection |  CollisionDetection |  | The [`CollisionDetection`](../collision_detection.md) rules. |
 | previous |  Optional[Action] |  | The previous action, if any. |
 | reset_arms |  bool |  | If True, reset the arms to their neutral positions while beginning the walk cycle. |

--- a/Documentation/python/replicant/actions/reach_for.md
+++ b/Documentation/python/replicant/actions/reach_for.md
@@ -77,7 +77,7 @@ See also: [`ReachForWithPlan`](reach_for_with_plan.md).
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| target |  Union[int, np.ndarray, Dict[str, float] |  | The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array. |
+| target |  TARGET |  | The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array. |
 | absolute |  bool |  | If True, the target position is in world space coordinates. If False, the target position is relative to the Replicant. Ignored if `target` is an int. |
 | offhand_follows |  bool |  | If True, the offhand will follow the primary hand, meaning that it will maintain the same relative position. Ignored if `len(arms) > 1` or if `target` is an object ID. |
 | arrived_at |  float |  | If the motion ends and the hand is this distance or less from the target, the action succeeds. |

--- a/Documentation/python/replicant/actions/reach_for_with_plan.md
+++ b/Documentation/python/replicant/actions/reach_for_with_plan.md
@@ -53,7 +53,7 @@ See also: [`ReachFor`](reach_for.md).
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | plan |  IkPlanType |  | An [`IkPlanType`](../ik_plans/ik_plan_type.md) that will define the [`IkPlan`](../ik_plans/ik_plan.md) this action will use. |
-| target |  Union[int, np.ndarray, Dict[str, float] |  | The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array. |
+| target |  TARGET |  | The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array. |
 | absolute |  bool |  | If True, the target position is in world space coordinates. If False, the target position is relative to the Replicant. Ignored if `target` is an int. |
 | arrived_at |  float |  | If the final [`ReachFor`](../actions/reach_for.md) action ends and the hand is this distance or less from the target, the motion succeeds. |
 | max_distance |  float |  | If at the start of the first [`ReachFor`](../actions/reach_for.md) action the target is further away than this distance from the hand, the action fails. |

--- a/Documentation/python/replicant/actions/turn_to.md
+++ b/Documentation/python/replicant/actions/turn_to.md
@@ -26,7 +26,7 @@ This is a non-animated action, meaning that the Replicant will immediately snap 
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| target |  Union[int, Dict[str, float] |  | The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array. |
+| target |  TARGET |  | The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array. |
 
 #### get_initialization_commands
 

--- a/Documentation/python/replicant/ik_plans/ik_plan.md
+++ b/Documentation/python/replicant/ik_plans/ik_plan.md
@@ -48,7 +48,7 @@ An `IkPlan` is used by the [`ReachForWithPlan`](../actions/reach_for_with_plan.m
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| target |  Union[int, np.ndarray, Dict[str, float] |  | The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array. |
+| target |  TARGET |  | The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array. |
 | absolute |  bool |  | If True, the target position is in world space coordinates. If False, the target position is relative to the Replicant. Ignored if `target` is an int. |
 | arrived_at |  float |  | If the final [`ReachFor`](../actions/reach_for.md) action ends and the hand is this distance or less from the target, the motion succeeds. |
 | max_distance |  float |  | If at the start of the first [`ReachFor`](../actions/reach_for.md) action the target is further away than this distance from the hand, the action fails. |

--- a/Documentation/python/replicant/ik_plans/vertical_horizontal.md
+++ b/Documentation/python/replicant/ik_plans/vertical_horizontal.md
@@ -45,7 +45,7 @@ Split a [`ReachFor`](../actions/reach_for.md) action into two actions:
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| target |  Union[int, np.ndarray, Dict[str, float] |  | The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array. |
+| target |  TARGET |  | The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array. |
 | absolute |  bool |  | If True, the target position is in world space coordinates. If False, the target position is relative to the Replicant. Ignored if `target` is an int. |
 | arrived_at |  float |  | If the final [`ReachFor`](../actions/reach_for.md) action ends and the hand is this distance or less from the target, the motion succeeds. |
 | max_distance |  float |  | If at the start of the first [`ReachFor`](../actions/reach_for.md) action the target is further away than this distance from the hand, the action fails. |

--- a/Documentation/python/robot_data/joint_dynamic.md
+++ b/Documentation/python/robot_data/joint_dynamic.md
@@ -27,7 +27,7 @@ Dynamic info for a joint that can change per-frame, such as its current position
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | joint_id |  int |  | The ID of this joint. |
-| position |  np.array |  | The worldspace position of this joint as an `[x, y, z]` numpy array. |
-| angles |  np.array |  | The angles of each axis of the joint in degrees as a numpy array. For prismatic joints, you need to convert this from degrees to radians in order to get the correct distance in meters. |
+| position |  np.ndarray |  | The worldspace position of this joint as an `[x, y, z]` numpy array. |
+| angles |  np.ndarray |  | The angles of each axis of the joint in degrees as a numpy array. For prismatic joints, you need to convert this from degrees to radians in order to get the correct distance in meters. |
 | moving |  bool |  | If True, this joint is currently moving. |
 

--- a/Documentation/python/type_aliases.md
+++ b/Documentation/python/type_aliases.md
@@ -1,0 +1,7 @@
+# tdw.type_aliases
+
+| Variable | Type | Value | Description |
+| --- | --- | --- | --- |
+| `TARGET` |  | Union[int, np.ndarray, Dict[str,  float]] | A target position or object: an integer (an object ID), a numpy array (a position), or a dictionary (a position). |
+| `POSITION` |  | Union[np.ndarray, Dict[str, float]] | A position: A numpy array or a dictionary. |
+| `ROTATION` |  | Union[np.ndarray, Dict[str, float]] | A rotation: A numpy array or a dictionary. |

--- a/Python/example_controllers/audio/impact_with_controller.py
+++ b/Python/example_controllers/audio/impact_with_controller.py
@@ -39,7 +39,7 @@ impact_sound_floor = py_impact_floor.name + "_4"
 py_impact = PyImpact(initial_amp=0.9, floor=py_impact_floor, resonance_audio=True)
 
 # Generate contact normals and set the collision velocity.
-contact_normals: List[np.array] = list()
+contact_normals: List[np.ndarray] = list()
 for i in range(3):
     contact_normals.append(np.array([0, 1, 0]))
 velocity = np.array([0, -1.5, 0])
@@ -60,7 +60,7 @@ while theta < 360:
     x = np.cos(rad) * distance
     z = np.sin(rad) * distance
     # Generate contact points around the sound's position.
-    contact_points: List[np.array] = list()
+    contact_points: List[np.ndarray] = list()
     contact_angle = 0
     for i in range(3):
         r = np.radians(contact_angle)

--- a/Python/example_controllers/audio/impact_without_controller.py
+++ b/Python/example_controllers/audio/impact_without_controller.py
@@ -12,7 +12,7 @@ output_directory = EXAMPLE_CONTROLLER_OUTPUT_PATH.joinpath("impact_without_contr
 if not output_directory.exists():
     output_directory.mkdir()
 print(f"Audio will be saved to: {output_directory}")
-contact_normals: List[np.array] = list()
+contact_normals: List[np.ndarray] = list()
 for i in range(3):
     contact_normals.append(np.array([0, 1, 0]))
 for i in range(5):

--- a/Python/example_controllers/audio/scrape_with_controller.py
+++ b/Python/example_controllers/audio/scrape_with_controller.py
@@ -40,7 +40,7 @@ impact_sound_floor = py_impact_floor.name + "_4"
 py_impact = PyImpact(initial_amp=0.9, floor=py_impact_floor, resonance_audio=True, rng=np.random.RandomState(0))
 
 # Generate contact normals and set the collision velocity.
-contact_normals: List[np.array] = list()
+contact_normals: List[np.ndarray] = list()
 for i in range(3):
     contact_normals.append(np.array([0, 1, 0]))
 velocity = np.array([1.5, 0, 0])
@@ -61,7 +61,7 @@ while theta < 360:
     x = np.cos(rad) * distance
     z = np.sin(rad) * distance
     # Generate contact points around the sound's position.
-    contact_points: List[np.array] = list()
+    contact_points: List[np.ndarray] = list()
     contact_angle = 0
     for i in range(3):
         r = np.radians(contact_angle)

--- a/Python/example_controllers/audio/scrape_without_controller.py
+++ b/Python/example_controllers/audio/scrape_without_controller.py
@@ -14,7 +14,7 @@ output_directory = EXAMPLE_CONTROLLER_OUTPUT_PATH.joinpath("scrape_without_contr
 if not output_directory.exists():
     output_directory.mkdir()
 print(f"Audio will be saved to: {output_directory}")
-contact_normals: List[np.array] = list()
+contact_normals: List[np.ndarray] = list()
 for i in range(3):
     contact_normals.append(np.array([0, 1, 0]))
 for i in range(5):

--- a/Python/example_controllers/camera_controls/footsteps.py
+++ b/Python/example_controllers/camera_controls/footsteps.py
@@ -63,8 +63,8 @@ for i in range(300):
         d_theta = int(360 / 3)
         r = 0.0625
         theta = 0
-        contact_points: List[np.array] = list()
-        contact_normals: List[np.array] = list()
+        contact_points: List[np.ndarray] = list()
+        contact_normals: List[np.ndarray] = list()
         while theta < 360:
             rad = radians(theta)
             x = cos(rad) * r + foot_position[0]

--- a/Python/example_controllers/core_concepts/object_output_data.py
+++ b/Python/example_controllers/core_concepts/object_output_data.py
@@ -33,7 +33,7 @@ commands = [TDWUtils.create_empty_room(12, 12),
 resp = c.communicate(commands)
 
 # The position of the object per frame.
-positions: List[np.array] = list()
+positions: List[np.ndarray] = list()
 # If True, the object has stopped moving.
 sleeping = False
 

--- a/Python/example_controllers/scene_setup_low_level/proc_gen_room.py
+++ b/Python/example_controllers/scene_setup_low_level/proc_gen_room.py
@@ -18,7 +18,7 @@ class ProcGenRoom(Controller):
     def create_scene(self) -> List[dict]:
         width: int = self.rng.randint(12, 18)
         length: int = self.rng.randint(14, 20)
-        room_arr: np.array = np.zeros(shape=(width, length), dtype=int)
+        room_arr: np.ndarray = np.zeros(shape=(width, length), dtype=int)
         # Define the uppermost width-wise wall.
         turn_south_at = int(length * 0.75) + self.rng.randint(1, 3)
         for i in range(turn_south_at + 1):

--- a/Python/example_controllers/vr/oculus_touch_axis_listener.py
+++ b/Python/example_controllers/vr/oculus_touch_axis_listener.py
@@ -32,7 +32,7 @@ class OculusTouchAxisListener(Controller):
             self.communicate([])
         self.communicate({"$type": "terminate"})
 
-    def left_axis(self, delta: np.array) -> None:
+    def left_axis(self, delta: np.ndarray) -> None:
         if self.robot.joints_are_moving():
             return
         targets = dict()
@@ -43,7 +43,7 @@ class OculusTouchAxisListener(Controller):
             targets[shoulder_link_id] = shoulder_link_angle + delta[0] * OculusTouchAxisListener.SPEED
         self.robot.set_joint_targets(targets=targets)
 
-    def right_axis(self, delta: np.array) -> None:
+    def right_axis(self, delta: np.ndarray) -> None:
         if self.robot.joints_are_moving():
             return
         targets = dict()

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from pathlib import Path
 import re
 
-__version__ = "1.11.19.0"
+__version__ = "1.11.19.1"
 readme_path = Path('../README.md')
 if readme_path.exists():
     long_description = readme_path.read_text(encoding='utf-8')

--- a/Python/tdw/add_ons/audio_initializer_base.py
+++ b/Python/tdw/add_ons/audio_initializer_base.py
@@ -1,10 +1,11 @@
 from abc import ABC, abstractmethod
 from base64 import b64encode
-from typing import List, Union, Dict
+from typing import List, Union
 from pathlib import Path
 import wave
 import numpy as np
 from overrides import final
+from tdw.type_aliases import POSITION
 from tdw.controller import Controller
 from tdw.tdw_utils import TDWUtils
 from tdw.add_ons.add_on import AddOn
@@ -56,7 +57,7 @@ class AudioInitializerBase(AddOn, ABC):
         return
 
     @final
-    def play(self, path: Union[str, Path], position: Union[np.array, Dict[str, float]], audio_id: int = None,
+    def play(self, path: Union[str, Path], position: POSITION, audio_id: int = None,
              object_id: int = None) -> None:
         """
         Load a .wav file and prepare to send a command to the build to play the audio.

--- a/Python/tdw/add_ons/cinematic_camera.py
+++ b/Python/tdw/add_ons/cinematic_camera.py
@@ -59,9 +59,9 @@ class CinematicCamera(ThirdPersonCameraBase):
         """
         self.field_of_view_speed: float = field_of_view_speed
         # The current forward directional vector of the image sensor.
-        self._sensor_forward: np.array = np.array([0, 0, 0])
+        self._sensor_forward: np.ndarray = np.array([0, 0, 0])
         # The current rotation of the image sensor.
-        self._sensor_rotation: np.array = np.array([0, 0, 0, 0])
+        self._sensor_rotation: np.ndarray = np.array([0, 0, 0, 0])
 
         # A target object ID or position to move towards. Can be None (no target).
         self._move_target: Optional[Union[int, Dict[str, float]]] = None

--- a/Python/tdw/add_ons/drone.py
+++ b/Python/tdw/add_ons/drone.py
@@ -20,12 +20,11 @@ class Drone(AddOn):
     """
     LIBRARY_NAME: str = "drones.json"
 
-    def __init__(self, drone_id: int = 0, position: POSITION = None,
-                 rotation: ROTATION = None, name: str = "drone",
+    def __init__(self, drone_id: int = 0, position: POSITION = None, rotation: ROTATION = None, name: str = "drone",
                  forward_speed: float = 3, backward_speed: float = 3, rise_speed: float = 3, drop_speed: float = 3,
-                 acceleration: float = 0.3, deceleration: float = 0.2, stability: float = 0.1, turn_sensitivity: float = 2,   
-                 enable_lights: bool = False, motor_on: bool = True, image_capture: bool = True,
-                 image_passes: List[str] = None):
+                 acceleration: float = 0.3, deceleration: float = 0.2, stability: float = 0.1,
+                 turn_sensitivity: float = 2, enable_lights: bool = False, motor_on: bool = True,
+                 image_capture: bool = True, image_passes: List[str] = None):
         """
         :param drone_id: The ID of the drone.
         :param position: The position of the drone as an x, y, z dictionary or numpy array. If None, defaults to `{"x": 0, "y": 0, "z": 0}`.

--- a/Python/tdw/add_ons/drone.py
+++ b/Python/tdw/add_ons/drone.py
@@ -1,5 +1,6 @@
-from typing import List, Optional, Dict, Union
+from typing import List, Optional, Dict
 import numpy as np
+from tdw.type_aliases import POSITION, ROTATION
 from tdw.add_ons.add_on import AddOn
 from tdw.drone.drone_dynamic import DroneDynamic
 from tdw.controller import Controller
@@ -19,8 +20,8 @@ class Drone(AddOn):
     """
     LIBRARY_NAME: str = "drones.json"
 
-    def __init__(self, drone_id: int = 0, position: Union[Dict[str, float], np.ndarray] = None,
-                 rotation: Union[Dict[str, float], np.ndarray] = None, name: str = "drone",
+    def __init__(self, drone_id: int = 0, position: POSITION = None,
+                 rotation: ROTATION = None, name: str = "drone",
                  forward_speed: float = 3, backward_speed: float = 3, rise_speed: float = 3, drop_speed: float = 3,
                  acceleration: float = 0.3, deceleration: float = 0.2, stability: float = 0.1, turn_sensitivity: float = 2,   
                  enable_lights: bool = False, motor_on: bool = True, image_capture: bool = True,

--- a/Python/tdw/add_ons/embodied_avatar.py
+++ b/Python/tdw/add_ons/embodied_avatar.py
@@ -48,7 +48,7 @@ class EmbodiedAvatar(ThirdPersonCameraBase):
         """:field
         The rotation of the camera as an [x, y, z, w] numpy array.
         """
-        self.camera_rotation: np.array = np.array([0, 0, 0, 0])
+        self.camera_rotation: np.ndarray = np.array([0, 0, 0, 0])
         """:field
         If True, the avatar is currently moving or turning.
         """

--- a/Python/tdw/add_ons/embodied_avatar.py
+++ b/Python/tdw/add_ons/embodied_avatar.py
@@ -1,5 +1,6 @@
 from typing import Dict, List, Union
 import numpy as np
+from tdw.type_aliases import TARGET
 from tdw.output_data import OutputData, AvatarSimpleBody, ImageSensors
 from tdw.tdw_utils import TDWUtils
 from tdw.add_ons.third_person_camera_base import ThirdPersonCameraBase
@@ -166,7 +167,7 @@ class EmbodiedAvatar(ThirdPersonCameraBase):
                                   "angle": rotation[q],
                                   "avatar_id": self.avatar_id})
 
-    def look_at(self, target: Union[int, Dict[str, float], np.ndarray]) -> None:
+    def look_at(self, target: TARGET) -> None:
         """
         Look at a target object or position.
 

--- a/Python/tdw/add_ons/mouse.py
+++ b/Python/tdw/add_ons/mouse.py
@@ -60,15 +60,15 @@ class Mouse(AddOn):
         """:field
         The (x, y) pixel position of the mouse on the screen.
         """
-        self.screen_position: np.array = np.array([0, 0])
+        self.screen_position: np.ndarray = np.array([0, 0])
         """:field
         The (x, y) scroll wheel delta.
         """
-        self.scroll_wheel_delta: np.array = np.array([0, 0])
+        self.scroll_wheel_delta: np.ndarray = np.array([0, 0])
         """:field
         The (x, y, z) world position of the mouse. The z depth coordinate is derived via a raycast.
         """
-        self.world_position: np.array = np.array([0, 0, 0])
+        self.world_position: np.ndarray = np.array([0, 0, 0])
         """:field
         If True, the mouse is currently over an object.
         """

--- a/Python/tdw/add_ons/object_manager.py
+++ b/Python/tdw/add_ons/object_manager.py
@@ -117,7 +117,7 @@ class ObjectManager(AddOn):
         """:field
         The segmentation color per category as use in the _category image pass. Key = The category. Value = The color as an `[r, g, b]` numpy array.
         """
-        self.categories: Dict[str, np.array] = dict()
+        self.categories: Dict[str, np.ndarray] = dict()
         """:field
         The [transform data](../object_data/transform.md) for each object on the scene on this frame. Key = The object ID. If `transforms=False` in the constructor, this dictionary will be empty.
         """
@@ -147,10 +147,10 @@ class ObjectManager(AddOn):
         if not self._cached_static_data:
             self._cached_static_data = True
             # Sort the static output data by object ID.
-            segmentation_colors: Dict[int, np.array] = dict()
+            segmentation_colors: Dict[int, np.ndarray] = dict()
             names: Dict[int, str] = dict()
             static_rigidbodies: Dict[int, _StaticRigidbody] = dict()
-            sizes: Dict[int, np.array] = dict()
+            sizes: Dict[int, np.ndarray] = dict()
             categories: Dict[int, str] = dict()
             for i in range(len(resp) - 1):
                 r_id = OutputData.get_data_type_id(resp[i])

--- a/Python/tdw/add_ons/oculus_touch.py
+++ b/Python/tdw/add_ons/oculus_touch.py
@@ -46,8 +46,8 @@ class OculusTouch(VR):
         self._button_press_events_left: Dict[OculusTouchButton, Callable[[], None]] = dict()
         self._button_press_events_right: Dict[OculusTouchButton, Callable[[], None]] = dict()
         # Axis events.
-        self._axis_events_left: List[Callable[[np.array], None]] = list()
-        self._axis_events_right: List[Callable[[np.array], None]] = list()
+        self._axis_events_left: List[Callable[[np.ndarray], None]] = list()
+        self._axis_events_right: List[Callable[[np.ndarray], None]] = list()
         # Non-graspable objects.
         if non_graspable is None:
             self._non_graspable: List[int] = list()
@@ -140,7 +140,7 @@ class OculusTouch(VR):
         else:
             self._button_press_events_right[button] = function
 
-    def listen_to_axis(self, is_left: bool, function: Callable[[np.array], None]) -> None:
+    def listen_to_axis(self, is_left: bool, function: Callable[[np.ndarray], None]) -> None:
         """
         Listen for Oculus Touch controller axis events.
 

--- a/Python/tdw/add_ons/py_impact.py
+++ b/Python/tdw/add_ons/py_impact.py
@@ -468,7 +468,7 @@ class PyImpact(CollisionManager):
                 t = np.append(t, jt * 1e3)
         return Modes(f, p, t)
 
-    def get_impact_sound(self, velocity: np.array, contact_normals: List[np.array],
+    def get_impact_sound(self, velocity: np.ndarray, contact_normals: List[np.ndarray],
                          primary_id: int, primary_material: str, primary_amp: float, primary_mass: float,
                          secondary_id: Optional[int], secondary_material: str, secondary_amp: float,
                          secondary_mass: float, primary_resonance: float, secondary_resonance: float) -> Optional[Base64Sound]:
@@ -564,8 +564,8 @@ class PyImpact(CollisionManager):
         sound = amp * sound / np.max(np.abs(sound))
         return Base64Sound(sound)
 
-    def get_impact_sound_command(self, velocity: np.array, contact_points: List[np.array],
-                                 contact_normals: List[np.array], primary_id: int,
+    def get_impact_sound_command(self, velocity: np.ndarray, contact_points: List[np.ndarray],
+                                 contact_normals: List[np.ndarray], primary_id: int,
                                  primary_material: str, primary_amp: float, primary_mass: float,
                                  secondary_id: Optional[int], secondary_material: str, secondary_amp: float,
                                  secondary_mass: float, primary_resonance: float, secondary_resonance: float) -> Optional[dict]:
@@ -642,10 +642,10 @@ class PyImpact(CollisionManager):
         snth = PyImpact._synth_impact_modes(modes_1, modes_2, mass, primary_resonance, secondary_resonance)
         return snth, modes_1, modes_2
 
-    def _get_impulse_response(self, velocity: np.array, contact_normals: List[np.array], primary_id: int,
+    def _get_impulse_response(self, velocity: np.ndarray, contact_normals: List[np.ndarray], primary_id: int,
                               primary_material: str, primary_amp: float, primary_mass: float,
                               secondary_id: int, secondary_material: str, secondary_amp: float, secondary_mass: float,
-                              primary_resonance: float, secondary_resonance: float) -> Tuple[np.array, float]:
+                              primary_resonance: float, secondary_resonance: float) -> Tuple[np.ndarray, float]:
         """
         Generate an impulse response from the modes for two specified objects.
 
@@ -677,8 +677,8 @@ class PyImpact(CollisionManager):
         h = Modes.mode_add(h1, h2)
         return h, min(modes_1.frequencies)
 
-    def get_scrape_sound_command(self, velocity: np.array, contact_points: np.array,
-                                 contact_normals: List[np.array], primary_id: int,
+    def get_scrape_sound_command(self, velocity: np.ndarray, contact_points: np.ndarray,
+                                 contact_normals: List[np.ndarray], primary_id: int,
                                  primary_material: str, primary_amp: float, primary_mass: float,
                                  secondary_id: Optional[int], secondary_material: str, secondary_amp: float,
                                  secondary_mass: float, primary_resonance: float, secondary_resonance: float,
@@ -723,7 +723,7 @@ class PyImpact(CollisionManager):
                                            contact_points=contact_points,
                                            sound=sound)
 
-    def get_scrape_sound(self, velocity: np.array, contact_normals: List[np.array], primary_id: int,
+    def get_scrape_sound(self, velocity: np.ndarray, contact_normals: List[np.ndarray], primary_id: int,
                          primary_material: str, primary_amp: float, primary_mass: float,
                          secondary_id: int, secondary_material: str, secondary_amp: float, secondary_mass: float,
                          primary_resonance: float, secondary_resonance: float, scrape_material: ScrapeMaterial) -> Optional[Base64Sound]:
@@ -892,7 +892,7 @@ class PyImpact(CollisionManager):
         return sound
 
     @staticmethod
-    def _synth_impact_modes(modes1: Modes, modes2: Modes, mass: float, primary_resonance: float, secondary_resonance: float) -> np.array:
+    def _synth_impact_modes(modes1: Modes, modes2: Modes, mass: float, primary_resonance: float, secondary_resonance: float) -> np.ndarray:
         """
         Generate an impact sound from specified modes for two objects, and the mass of the smaller object.
 
@@ -1032,7 +1032,7 @@ class PyImpact(CollisionManager):
         robot_joints: Dict[int, dict] = dict()
         object_masses: Dict[int, float] = dict()
         object_bouncinesses: Dict[int, float] = dict()
-        extents: Dict[int, np.array] = dict()
+        extents: Dict[int, np.ndarray] = dict()
         vr_nodes: List[ObjectAudioStatic] = list()
         for i in range(len(resp) - 1):
             r_id = OutputData.get_data_type_id(resp[i])
@@ -1167,7 +1167,7 @@ class PyImpact(CollisionManager):
             self._static_audio_data[vr_node.object_id] = vr_node
 
     @staticmethod
-    def _normalize_16bit_int(arr: np.array) -> np.array:
+    def _normalize_16bit_int(arr: np.ndarray) -> np.ndarray:
         """
         Convert numpy float array to normalized 16-bit integers.
 
@@ -1181,7 +1181,7 @@ class PyImpact(CollisionManager):
         return (normalized_floats * 32767).astype(np.int16)
 
     @staticmethod
-    def _normalize_floats(arr: np.array) -> np.array:
+    def _normalize_floats(arr: np.ndarray) -> np.ndarray:
         """
         Normalize numpy array of float audio data.
 
@@ -1211,7 +1211,7 @@ class PyImpact(CollisionManager):
         if scrape_key in self._scrape_previous_indices:
             del self._scrape_previous_indices[scrape_key]
 
-    def _get_audio_command(self, audio_source_id: int, contact_points: np.array, sound: Base64Sound) -> dict:
+    def _get_audio_command(self, audio_source_id: int, contact_points: np.ndarray, sound: Base64Sound) -> dict:
         """
         :param audio_source_id: The audio source ID.
         :param contact_points: The collision contact points.

--- a/Python/tdw/add_ons/replicant.py
+++ b/Python/tdw/add_ons/replicant.py
@@ -44,8 +44,7 @@ class Replicant(AddOn):
     """
     LIBRARY_NAME: str = "replicants.json"
 
-    def __init__(self, replicant_id: int = 0, position: POSITION = None,
-                 rotation: ROTATION = None,
+    def __init__(self, replicant_id: int = 0, position: POSITION = None, rotation: ROTATION = None,
                  image_frequency: ImageFrequency = ImageFrequency.once, name: str = "replicant_0",
                  target_framerate: int = 100):
         """
@@ -260,9 +259,9 @@ class Replicant(AddOn):
                              arrived_at=arrived_at,
                              max_walk_cycles=max_walk_cycles)
 
-    def move_to(self, target: TARGET, reset_arms: bool = True,
-                reset_arms_duration: float = 0.25, scale_reset_arms_duration: bool = True, arrived_at: float = 0.1,
-                max_walk_cycles: int = 100, bounds_position: str = "center") -> None:
+    def move_to(self, target: TARGET, reset_arms: bool = True, reset_arms_duration: float = 0.25,
+                scale_reset_arms_duration: bool = True, arrived_at: float = 0.1, max_walk_cycles: int = 100,
+                bounds_position: str = "center") -> None:
         """
         Turn the Replicant to a target position or object and then walk to it.
 
@@ -299,10 +298,10 @@ class Replicant(AddOn):
                              max_walk_cycles=max_walk_cycles,
                              bounds_position=bounds_position)
 
-    def reach_for(self, target: TARGET, arm: Union[Arm, List[Arm]],
-                  absolute: bool = True, offhand_follows: bool = False, arrived_at: float = 0.09,
-                  max_distance: float = 1.5, duration: float = 0.25, scale_duration: bool = True,
-                  from_held: bool = False, held_point: str = "bottom", plan: IkPlanType = None) -> None:
+    def reach_for(self, target: TARGET, arm: Union[Arm, List[Arm]], absolute: bool = True,
+                  offhand_follows: bool = False, arrived_at: float = 0.09, max_distance: float = 1.5,
+                  duration: float = 0.25, scale_duration: bool = True, from_held: bool = False,
+                  held_point: str = "bottom", plan: IkPlanType = None) -> None:
         """
         Reach for a target object or position. One or both hands can reach for the target at the same time.
 
@@ -440,8 +439,7 @@ class Replicant(AddOn):
                                duration=duration,
                                scale_duration=scale_duration)
 
-    def look_at(self, target: TARGET, duration: float = 0.1,
-                scale_duration: bool = True):
+    def look_at(self, target: TARGET, duration: float = 0.1, scale_duration: bool = True):
         """
         Look at a target object or position.
 

--- a/Python/tdw/add_ons/replicant.py
+++ b/Python/tdw/add_ons/replicant.py
@@ -1,7 +1,7 @@
 from typing import List, Optional, Dict, Union
 from copy import deepcopy
 import numpy as np
-from tdw.type_aliases import TARGET
+from tdw.type_aliases import TARGET, POSITION, ROTATION
 from tdw.add_ons.add_on import AddOn
 from tdw.replicant.replicant_static import ReplicantStatic
 from tdw.replicant.replicant_dynamic import ReplicantDynamic
@@ -44,8 +44,8 @@ class Replicant(AddOn):
     """
     LIBRARY_NAME: str = "replicants.json"
 
-    def __init__(self, replicant_id: int = 0, position: Union[Dict[str, float], np.ndarray] = None,
-                 rotation: Union[Dict[str, float], np.ndarray] = None,
+    def __init__(self, replicant_id: int = 0, position: POSITION = None,
+                 rotation: ROTATION = None,
                  image_frequency: ImageFrequency = ImageFrequency.once, name: str = "replicant_0",
                  target_framerate: int = 100):
         """
@@ -480,8 +480,7 @@ class Replicant(AddOn):
 
         self.action = ResetHead(duration=duration, scale_duration=scale_duration)
 
-    def reset(self, position: Union[Dict[str, float], np.ndarray] = None,
-              rotation: Union[Dict[str, float], np.ndarray] = None) -> None:
+    def reset(self, position: POSITION = None, rotation: ROTATION = None) -> None:
         """
         Reset the Replicant. Call this when you reset the scene.
 
@@ -499,10 +498,9 @@ class Replicant(AddOn):
         self._set_initial_position_and_rotation(position=position, rotation=rotation)
         self.commands.clear()
 
-    def _set_initial_position_and_rotation(self, position: Union[Dict[str, float], np.ndarray] = None,
-                                           rotation: Union[Dict[str, float], np.ndarray] = None) -> None:
+    def _set_initial_position_and_rotation(self, position: POSITION = None, rotation: ROTATION = None) -> None:
         """
-        Set the intial position and rotation.
+        Set the initial position and rotation.
 
         :param position: The position of the Replicant as an x, y, z dictionary or numpy array. If None, defaults to `{"x": 0, "y": 0, "z": 0}`.
         :param rotation: The rotation of the Replicant in Euler angles (degrees) as an x, y, z dictionary or numpy array. If None, defaults to `{"x": 0, "y": 0, "z": 0}`.

--- a/Python/tdw/add_ons/replicant.py
+++ b/Python/tdw/add_ons/replicant.py
@@ -1,6 +1,7 @@
 from typing import List, Optional, Dict, Union
 from copy import deepcopy
 import numpy as np
+from tdw.type_aliases import TARGET
 from tdw.add_ons.add_on import AddOn
 from tdw.replicant.replicant_static import ReplicantStatic
 from tdw.replicant.replicant_dynamic import ReplicantDynamic
@@ -211,7 +212,7 @@ class Replicant(AddOn):
 
         self.action = TurnBy(angle=angle)
 
-    def turn_to(self, target: Union[int, Dict[str, float], np.ndarray]) -> None:
+    def turn_to(self, target: TARGET) -> None:
         """
         Turn the Replicant to face a target object or position.
 
@@ -259,7 +260,7 @@ class Replicant(AddOn):
                              arrived_at=arrived_at,
                              max_walk_cycles=max_walk_cycles)
 
-    def move_to(self, target: Union[int, Dict[str, float], np.ndarray], reset_arms: bool = True,
+    def move_to(self, target: TARGET, reset_arms: bool = True,
                 reset_arms_duration: float = 0.25, scale_reset_arms_duration: bool = True, arrived_at: float = 0.1,
                 max_walk_cycles: int = 100, bounds_position: str = "center") -> None:
         """
@@ -298,7 +299,7 @@ class Replicant(AddOn):
                              max_walk_cycles=max_walk_cycles,
                              bounds_position=bounds_position)
 
-    def reach_for(self, target: Union[int, Dict[str,  float], np.ndarray], arm: Union[Arm, List[Arm]],
+    def reach_for(self, target: TARGET, arm: Union[Arm, List[Arm]],
                   absolute: bool = True, offhand_follows: bool = False, arrived_at: float = 0.09,
                   max_distance: float = 1.5, duration: float = 0.25, scale_duration: bool = True,
                   from_held: bool = False, held_point: str = "bottom", plan: IkPlanType = None) -> None:
@@ -439,7 +440,7 @@ class Replicant(AddOn):
                                duration=duration,
                                scale_duration=scale_duration)
 
-    def look_at(self, target: Union[int, np.ndarray, Dict[str,  float]], duration: float = 0.1,
+    def look_at(self, target: TARGET, duration: float = 0.1,
                 scale_duration: bool = True):
         """
         Look at a target object or position.

--- a/Python/tdw/add_ons/robot_arm.py
+++ b/Python/tdw/add_ons/robot_arm.py
@@ -3,6 +3,7 @@ import numpy as np
 from overrides import final
 from ikpy.chain import Chain
 from ikpy.link import OriginLink, URDFLink, Link
+from tdw.type_aliases import POSITION
 from tdw.tdw_utils import TDWUtils
 from tdw.quaternion_utils import QuaternionUtils
 from tdw.add_ons.robot import Robot
@@ -42,7 +43,7 @@ class RobotArm(Robot):
         # Set robot arm IK chain.
         self._chain: Chain = Chain(name=name, links=links)
 
-    def reach_for(self, target: Union[Dict[str, float], np.array]) -> None:
+    def reach_for(self, target: POSITION) -> None:
         """
         Start to reach for a target position.
 
@@ -86,7 +87,7 @@ class RobotArm(Robot):
         super().stop_joints(joint_ids=joint_ids)
 
     @final
-    def _get_ik_angles(self, target: Union[Dict[str, float], np.array]) -> List[float]:
+    def _get_ik_angles(self, target: POSITION) -> List[float]:
         """
         :param target: The target position to reach for.
 
@@ -106,7 +107,7 @@ class RobotArm(Robot):
         return self._chain.inverse_kinematics(target_position=relative_target, initial_position=initial_angles)
 
     @final
-    def _absolute_to_relative(self, target: np.array) -> np.array:
+    def _absolute_to_relative(self, target: np.ndarray) -> np.ndarray:
         """
         :param target: The target position.
         :return: The target position in relative coordinates.

--- a/Python/tdw/add_ons/vehicle.py
+++ b/Python/tdw/add_ons/vehicle.py
@@ -1,5 +1,6 @@
-from typing import List, Optional, Dict, Union
+from typing import List, Optional, Dict
 import numpy as np
+from tdw.type_aliases import POSITION, ROTATION
 from tdw.add_ons.add_on import AddOn
 from tdw.vehicle.vehicle_dynamic import VehicleDynamic
 from tdw.controller import Controller
@@ -19,8 +20,8 @@ class Vehicle(AddOn):
     """
     LIBRARY_NAME: str = "vehicles.json"
 
-    def __init__(self, vehicle_id: int = 0, position: Union[Dict[str, float], np.ndarray] = None,
-                 rotation: Union[Dict[str, float], np.ndarray] = None, name: str = "all_terrain_vehicle",
+    def __init__(self, vehicle_id: int = 0, position: POSITION = None,
+                 rotation: ROTATION = None, name: str = "all_terrain_vehicle",
                  forward_speed: float = 30, reverse_speed: float = 12, image_capture: bool = True,
                  image_passes: List[str] = None):
         """

--- a/Python/tdw/add_ons/vehicle.py
+++ b/Python/tdw/add_ons/vehicle.py
@@ -20,10 +20,9 @@ class Vehicle(AddOn):
     """
     LIBRARY_NAME: str = "vehicles.json"
 
-    def __init__(self, vehicle_id: int = 0, position: POSITION = None,
-                 rotation: ROTATION = None, name: str = "all_terrain_vehicle",
-                 forward_speed: float = 30, reverse_speed: float = 12, image_capture: bool = True,
-                 image_passes: List[str] = None):
+    def __init__(self, vehicle_id: int = 0, position: POSITION = None, rotation: ROTATION = None,
+                 name: str = "all_terrain_vehicle", forward_speed: float = 30, reverse_speed: float = 12,
+                 image_capture: bool = True, image_passes: List[str] = None):
         """
         :param vehicle_id: The ID of the vehicle.
         :param position: The position of the vehicle as an x, y, z dictionary or numpy array. If None, defaults to `{"x": 0, "y": 0, "z": 0}`.

--- a/Python/tdw/add_ons/vr.py
+++ b/Python/tdw/add_ons/vr.py
@@ -66,11 +66,11 @@ class VR(AddOn, ABC):
         """:field
         A numpy of object IDs held by the left hand.
         """
-        self.held_left: np.array = np.array([], dtype=int)
+        self.held_left: np.ndarray = np.array([], dtype=int)
         """:field
         A numpy of object IDs held by the right hand.
         """
-        self.held_right: np.array = np.array([], dtype=int)
+        self.held_right: np.ndarray = np.array([], dtype=int)
 
     def get_initialization_commands(self) -> List[dict]:
         """

--- a/Python/tdw/collision_data/collision_base.py
+++ b/Python/tdw/collision_data/collision_base.py
@@ -17,11 +17,11 @@ class CollisionBase(ABC):
         """:field
         The contact point positions.
         """
-        self.points: List[np.array] = list()
+        self.points: List[np.ndarray] = list()
         """:field
         The contact point normals.
         """
-        self.normals: List[np.array] = list()
+        self.normals: List[np.ndarray] = list()
         for i in range(collision.get_num_contacts()):
             self.points.append(np.array(collision.get_contact_point(i)))
             self.normals.append(np.array(collision.get_contact_normal(i)))

--- a/Python/tdw/collision_data/collision_obj_obj.py
+++ b/Python/tdw/collision_data/collision_obj_obj.py
@@ -17,8 +17,8 @@ class CollisionObjObj(CollisionBase):
         """:field
         The relative velocity of the objects.
         """
-        self.relative_velocity: np.array = np.array(collision.get_relative_velocity())
+        self.relative_velocity: np.ndarray = np.array(collision.get_relative_velocity())
         """:field
         The total impulse applied to the pair of objects to resolve the collision.
         """
-        self.impulse: np.array = np.array(collision.get_impulse())
+        self.impulse: np.ndarray = np.array(collision.get_impulse())

--- a/Python/tdw/obi_data/obi_actor.py
+++ b/Python/tdw/obi_data/obi_actor.py
@@ -23,11 +23,11 @@ class ObiActor:
         """:field
         The positions of each particle as a numpy array.
         """
-        self.positions: np.array = np.array([], dtype=np.float32)
+        self.positions: np.ndarray = np.array([], dtype=np.float32)
         """:field
         The velocities of each particle as a numpy array.
         """
-        self.velocities: np.array = np.array([], dtype=np.float32)
+        self.velocities: np.ndarray = np.array([], dtype=np.float32)
 
     def on_communicate(self, obi_particles: ObiParticles) -> None:
         """

--- a/Python/tdw/object_data/bound.py
+++ b/Python/tdw/object_data/bound.py
@@ -6,8 +6,8 @@ class Bound:
     Bounds data for a single object.
     """
 
-    def __init__(self, front: np.array, back: np.array, left: np.array, right: np.array, top: np.array,
-                 bottom: np.array, center: np.array):
+    def __init__(self, front: np.ndarray, back: np.ndarray, left: np.ndarray, right: np.ndarray, top: np.ndarray,
+                 bottom: np.ndarray, center: np.ndarray):
         """
         :param front: The position of the front point.
         :param back: The position of the back point.
@@ -21,28 +21,28 @@ class Bound:
         """:field
         The position of the front point.
         """
-        self.front: np.array = front
+        self.front: np.ndarray = front
         """:field
         The position of the back point.
         """
-        self.back: np.array = back
+        self.back: np.ndarray = back
         """:field
         The position of the left point.
         """
-        self.left: np.array = left
+        self.left: np.ndarray = left
         """:field
         The position of the right point.
         """
-        self.right: np.array = right
+        self.right: np.ndarray = right
         """:field
         The position of the top point.
         """
-        self.top: np.array = top
+        self.top: np.ndarray = top
         """:field
         The position of the bottom point.
         """
-        self.bottom: np.array = bottom
+        self.bottom: np.ndarray = bottom
         """:field
         The position of the center point.
         """
-        self.center: np.array = center
+        self.center: np.ndarray = center

--- a/Python/tdw/object_data/composite_object/sub_object/hinge_static.py
+++ b/Python/tdw/object_data/composite_object/sub_object/hinge_static.py
@@ -25,5 +25,5 @@ class HingeStatic(HingeStaticBase):
         return static_composite_objects.get_hinge_max_limit(object_index, sub_object_index)
 
     def _get_axis(self, static_composite_objects: StaticCompositeObjects, object_index: int,
-                  sub_object_index: int) -> np.array:
+                  sub_object_index: int) -> np.ndarray:
         return np.array(static_composite_objects.get_hinge_axis(object_index, sub_object_index))

--- a/Python/tdw/object_data/composite_object/sub_object/hinge_static_base.py
+++ b/Python/tdw/object_data/composite_object/sub_object/hinge_static_base.py
@@ -36,8 +36,8 @@ class HingeStaticBase(SubObjectStatic, ABC):
         """:field
         The axis of rotation.
         """
-        self.axis: np.array = self._get_axis(static_composite_objects=static_composite_objects,
-                                             object_index=object_index, sub_object_index=sub_object_index)
+        self.axis: np.ndarray = self._get_axis(static_composite_objects=static_composite_objects,
+                                               object_index=object_index, sub_object_index=sub_object_index)
 
     @abstractmethod
     def _get_has_limits(self, static_composite_objects: StaticCompositeObjects, object_index: int,
@@ -80,7 +80,7 @@ class HingeStaticBase(SubObjectStatic, ABC):
 
     @abstractmethod
     def _get_axis(self, static_composite_objects: StaticCompositeObjects, object_index: int,
-                  sub_object_index: int) -> np.array:
+                  sub_object_index: int) -> np.ndarray:
         """
         :param static_composite_objects: `StaticCompositeObjects` output data.
         :param object_index: The object index.

--- a/Python/tdw/object_data/composite_object/sub_object/motor_static.py
+++ b/Python/tdw/object_data/composite_object/sub_object/motor_static.py
@@ -39,5 +39,5 @@ class MotorStatic(HingeStaticBase):
         return static_composite_objects.get_motor_max_limit(object_index, sub_object_index)
 
     def _get_axis(self, static_composite_objects: StaticCompositeObjects, object_index: int,
-                  sub_object_index: int) -> np.array:
+                  sub_object_index: int) -> np.ndarray:
         return np.array(static_composite_objects.get_motor_axis(object_index, sub_object_index))

--- a/Python/tdw/object_data/composite_object/sub_object/prismatic_joint_static.py
+++ b/Python/tdw/object_data/composite_object/sub_object/prismatic_joint_static.py
@@ -24,7 +24,7 @@ class PrismaticJointStatic(SubObjectStatic):
         """:field
         The axis of movement.
         """
-        self.axis: np.array = np.array(static_composite_objects.get_prismatic_joint_axis(object_index, sub_object_index))
+        self.axis: np.ndarray = np.array(static_composite_objects.get_prismatic_joint_axis(object_index, sub_object_index))
 
     def _get_sub_object_id(self, static_composite_objects: StaticCompositeObjects, object_index: int,
                            sub_object_index: int) -> int:

--- a/Python/tdw/object_data/composite_object/sub_object/spring_static.py
+++ b/Python/tdw/object_data/composite_object/sub_object/spring_static.py
@@ -43,5 +43,5 @@ class SpringStatic(HingeStaticBase):
         return static_composite_objects.get_spring_max_limit(object_index, sub_object_index)
 
     def _get_axis(self, static_composite_objects: StaticCompositeObjects, object_index: int,
-                  sub_object_index: int) -> np.array:
+                  sub_object_index: int) -> np.ndarray:
         return np.array(static_composite_objects.get_spring_axis(object_index, sub_object_index))

--- a/Python/tdw/object_data/object_static.py
+++ b/Python/tdw/object_data/object_static.py
@@ -6,7 +6,7 @@ class ObjectStatic:
     Static data for an object. This data won't change between frames.
     """
 
-    def __init__(self, name: str, object_id: int, mass: float, segmentation_color: np.array, size: np.array,
+    def __init__(self, name: str, object_id: int, mass: float, segmentation_color: np.ndarray, size: np.ndarray,
                  category: str, kinematic: bool, dynamic_friction: float, static_friction: float, bounciness: float):
         """
         :param name: The name of the object.
@@ -35,19 +35,19 @@ class ObjectStatic:
         """:field
         If True, this object is kinematic, and won't respond to physics. 
         """
-        self.kinematic = kinematic
+        self.kinematic: bool = kinematic
         """:field
         The RGB segmentation color for the object as a numpy array: `[r, g, b]`
         """
-        self.segmentation_color = segmentation_color
+        self.segmentation_color: np.ndarray = segmentation_color
         """:field
         The mass of the object.
         """
-        self.mass = mass
+        self.mass: float = mass
         """:field
         The size of the object as a numpy array: `[width, height, length]`
         """
-        self.size = size
+        self.size: np.ndarray = size
         """:field
         The dynamic friction of the object.
         """

--- a/Python/tdw/object_data/rigidbody.py
+++ b/Python/tdw/object_data/rigidbody.py
@@ -6,7 +6,7 @@ class Rigidbody:
     Dynamic object rigidbody data. Note that this excludes *static* rigidbody data such as the mass of the object.
     """
 
-    def __init__(self, velocity: np.array, angular_velocity: np.array, sleeping: bool):
+    def __init__(self, velocity: np.ndarray, angular_velocity: np.ndarray, sleeping: bool):
         """
         :param velocity: The directional velocity of the object.
         :param angular_velocity: The angular velocity of the object.
@@ -16,11 +16,11 @@ class Rigidbody:
         """:field
         The directional velocity of the object.
         """
-        self.velocity: np.array = velocity
+        self.velocity: np.ndarray = velocity
         """:field
         The angular velocity of the object.
         """
-        self.angular_velocity: np.array = angular_velocity
+        self.angular_velocity: np.ndarray = angular_velocity
         """:field
         If True, the object isn't moving.
         """

--- a/Python/tdw/object_data/transform.py
+++ b/Python/tdw/object_data/transform.py
@@ -6,7 +6,7 @@ class Transform:
     Positional data for an object, robot body part, etc.
     """
 
-    def __init__(self, position: np.array, rotation: np.array, forward: np.array):
+    def __init__(self, position: np.ndarray, rotation: np.ndarray, forward: np.ndarray):
         """
         :param position: The position vector of the object as a numpy array.
         :param rotation: The rotation quaternion of the object as a numpy array.

--- a/Python/tdw/output_data.py
+++ b/Python/tdw/output_data.py
@@ -183,13 +183,13 @@ class Transforms(OutputData):
     def get_id(self, index: int) -> int:
         return int(self._ids[index])
 
-    def get_position(self, index: int) -> np.array:
+    def get_position(self, index: int) -> np.ndarray:
         return self._positions[index]
 
-    def get_forward(self, index: int) -> np.array:
+    def get_forward(self, index: int) -> np.ndarray:
         return self._forwards[index]
 
-    def get_rotation(self, index: int) -> np.array:
+    def get_rotation(self, index: int) -> np.ndarray:
         return self._rotations[index]
 
 
@@ -210,10 +210,10 @@ class Rigidbodies(OutputData):
     def get_id(self, index: int) -> int:
         return int(self._ids[index])
 
-    def get_velocity(self, index: int) -> np.array:
+    def get_velocity(self, index: int) -> np.ndarray:
         return self._velocities[index]
 
-    def get_angular_velocity(self, index: int) -> np.array:
+    def get_angular_velocity(self, index: int) -> np.ndarray:
         return self._angular_velocities[index]
 
     def get_sleeping(self, index: int) -> bool:
@@ -267,25 +267,25 @@ class Bounds(OutputData):
     def get_id(self, index: int) -> int:
         return int(self._ids[index])
 
-    def get_front(self, index: int) -> np.array:
+    def get_front(self, index: int) -> np.ndarray:
         return self._bounds_positions[index][0]
 
-    def get_back(self, index: int) -> np.array:
+    def get_back(self, index: int) -> np.ndarray:
         return self._bounds_positions[index][1]
 
-    def get_left(self, index: int) -> np.array:
+    def get_left(self, index: int) -> np.ndarray:
         return self._bounds_positions[index][3]
 
-    def get_right(self, index: int) -> np.array:
+    def get_right(self, index: int) -> np.ndarray:
         return self._bounds_positions[index][2]
 
-    def get_top(self, index: int) -> np.array:
+    def get_top(self, index: int) -> np.ndarray:
         return self._bounds_positions[index][4]
 
-    def get_bottom(self, index: int) -> np.array:
+    def get_bottom(self, index: int) -> np.ndarray:
         return self._bounds_positions[index][5]
 
-    def get_center(self, index: int) -> np.array:
+    def get_center(self, index: int) -> np.ndarray:
         return self._bounds_positions[index][6]
 
 
@@ -316,7 +316,7 @@ class Images(OutputData):
     def get_pass_mask(self, index: int) -> str:
         return Images.PASS_MASKS[self.data.Passes(index).PassMask()]
 
-    def get_image(self, index: int) -> np.array:
+    def get_image(self, index: int) -> np.ndarray:
         return self.data.Passes(index).ImageAsNumpy()
 
     def get_extension(self, index: int) -> str:
@@ -386,7 +386,7 @@ class SegmentationColors(OutputData):
     def get_object_id(self, index: int) -> int:
         return int(self._ids[index])
 
-    def get_object_color(self, index: int) -> np.array:
+    def get_object_color(self, index: int) -> np.ndarray:
         return self._colors[index]
 
     def get_object_name(self, index: int) -> str:
@@ -506,17 +506,17 @@ class CameraMatrices(OutputData):
     def get_sensor_name(self) -> str:
         return self.data.SensorName().decode('utf-8')
 
-    def get_projection_matrix(self) -> np.array:
+    def get_projection_matrix(self) -> np.ndarray:
         return self.data.ProjectionMatrixAsNumpy()
 
-    def get_camera_matrix(self) -> np.array:
+    def get_camera_matrix(self) -> np.ndarray:
         return self.data.CameraMatrixAsNumpy()
 
 
 class IdPassSegmentationColors(OutputData):
     def __init__(self, b):
         super().__init__(b)
-        self._colors: np.array = self.data.SegmentationColorsAsNumpy().reshape(-1, 3)
+        self._colors: np.ndarray = self.data.SegmentationColorsAsNumpy().reshape(-1, 3)
 
     def get_data(self) -> IdSC.IdPassSegmentationColors:
         return IdSC.IdPassSegmentationColors.GetRootAsIdPassSegmentationColors(self.bytes, 0)
@@ -527,7 +527,7 @@ class IdPassSegmentationColors(OutputData):
     def get_num_segmentation_colors(self) -> int:
         return self._colors.shape[0]
 
-    def get_segmentation_color(self, index: int) -> np.array:
+    def get_segmentation_color(self, index: int) -> np.ndarray:
         return self._colors[index]
 
 
@@ -538,10 +538,10 @@ class FlexParticles(OutputData):
     def get_num_objects(self) -> int:
         return self.data.ObjectsLength()
 
-    def get_particles(self, index: int) -> np.array:
+    def get_particles(self, index: int) -> np.ndarray:
         return self.data.Objects(index).ParticlesAsNumpy().view(dtype=np.float32).reshape(-1, 4)
 
-    def get_velocities(self, index: int) -> np.array:
+    def get_velocities(self, index: int) -> np.ndarray:
         return self.data.Objects(index).VelocitiesAsNumpy().view(dtype=np.float32).reshape(-1, 3)
 
     def get_id(self, index: int) -> int:
@@ -607,10 +607,10 @@ class VRRig(OutputData):
     def get_head_forward(self) -> Tuple[float, float, float]:
         return OutputData._get_vector3(self._get_simple_transform(2).Forward)
 
-    def get_held_left(self) -> np.array:
+    def get_held_left(self) -> np.ndarray:
         return self.data.HeldLeftAsNumpy()
 
-    def get_held_right(self) -> np.array:
+    def get_held_right(self) -> np.ndarray:
         return self.data.HeldRightAsNumpy()
 
 
@@ -626,10 +626,10 @@ class OculusTouchButtons(OutputData):
     def get_right(self) -> List[OculusTouchButton]:
         return self._get_buttons(v=self.data.Right())
 
-    def get_left_axis(self) -> np.array:
+    def get_left_axis(self) -> np.ndarray:
         return self.data.LeftAxisAsNumpy()
 
-    def get_right_axis(self) -> np.array:
+    def get_right_axis(self) -> np.ndarray:
         return self.data.RightAxisAsNumpy()
 
     @staticmethod
@@ -683,10 +683,10 @@ class Meshes(OutputData):
     def get_num(self) -> int:
         return self.data.ObjectsLength()
 
-    def get_vertices(self, index: int) -> np.array:
+    def get_vertices(self, index: int) -> np.ndarray:
         return self.data.Objects(index).VerticesAsNumpy().view(dtype=np.float32).reshape(-1, 3)
 
-    def get_triangles(self, index: int) -> np.array:
+    def get_triangles(self, index: int) -> np.ndarray:
         return self.data.Objects(index).TrianglesAsNumpy().view(dtype=np.int32).reshape(-1, 3)
 
 
@@ -782,7 +782,7 @@ class AudioSources(OutputData):
     def get_is_playing(self, index: int) -> bool:
         return self.data.Objects(index).IsPlaying()
 
-    def get_samples(self) -> np.array:
+    def get_samples(self) -> np.ndarray:
         return self.data.SamplesAsNumpy()
 
 
@@ -824,7 +824,7 @@ class Overlap(OutputData):
     def get_id(self) -> int:
         return self.data.Id()
 
-    def get_object_ids(self) -> np.array:
+    def get_object_ids(self) -> np.ndarray:
         return self.data.ObjectIdsAsNumpy()
 
     def get_env(self) -> bool:
@@ -872,7 +872,7 @@ class NavMeshPath(OutputData):
     def get_state(self) -> str:
         return NavMeshPath._STATES[self.data.State()]
 
-    def get_path(self) -> np.array:
+    def get_path(self) -> np.ndarray:
         return self.data.PathAsNumpy().view(dtype=np.float32).reshape(-1, 3)
 
     def get_id(self) -> int:
@@ -957,7 +957,7 @@ class StaticRobot(OutputData):
     def get_non_moving_segmentation_color(self, index: int) -> Tuple[float, float, float]:
         return OutputData._get_rgb(self.data.NonMoving(index).SegmentationColor())
 
-    def get_joint_indices(self) -> np.array:
+    def get_joint_indices(self) -> np.ndarray:
         return self.data.JointIndicesAsNumpy().reshape(-1, 2)
 
     def get_robot_index(self) -> int:
@@ -977,10 +977,10 @@ class RobotJointVelocities(OutputData):
     def get_joint_id(self, index: int) -> int:
         return self.data.Joints(index).Id()
 
-    def get_joint_velocity(self, index: int) -> np.array:
+    def get_joint_velocity(self, index: int) -> np.ndarray:
         return self.data.Joints(index).VelocityAsNumpy()
 
-    def get_joint_angular_velocity(self, index: int) -> np.array:
+    def get_joint_angular_velocity(self, index: int) -> np.ndarray:
         return self.data.Joints(index).AngularVelocityAsNumpy()
 
     def get_joint_sleeping(self, index: int) -> bool:
@@ -1001,19 +1001,19 @@ class DynamicRobots(OutputData):
     def get_immovable(self, index: int) -> bool:
         return bool(self._immovable[index])
 
-    def get_robot_position(self, index: int) -> np.array:
+    def get_robot_position(self, index: int) -> np.ndarray:
         return self._transforms[index][:3]
 
-    def get_robot_rotation(self, index: int) -> np.array:
+    def get_robot_rotation(self, index: int) -> np.ndarray:
         return self._transforms[index][3:7]
 
-    def get_robot_forward(self, index: int) -> np.array:
+    def get_robot_forward(self, index: int) -> np.ndarray:
         return self._transforms[index][7:]
 
-    def get_joint_position(self, index: int) -> np.array:
+    def get_joint_position(self, index: int) -> np.ndarray:
         return self._joints[index][0]
 
-    def get_joint_angles(self, index: int) -> np.array:
+    def get_joint_angles(self, index: int) -> np.ndarray:
         return np.degrees(self._joints[index][1])
 
     def get_joint_sleeping(self, index: int) -> bool:
@@ -1070,10 +1070,10 @@ class Magnebot(OutputData):
     def get_id(self) -> int:
         return self.data.Id()
 
-    def get_held_left(self) -> np.array:
+    def get_held_left(self) -> np.ndarray:
         return self.data.HeldLeftAsNumpy()
 
-    def get_held_right(self) -> np.array:
+    def get_held_right(self) -> np.ndarray:
         return self.data.HeldRightAsNumpy()
 
     def get_top(self) -> Tuple[float, float, float]:
@@ -1121,16 +1121,16 @@ class LocalTransforms(OutputData):
     def get_id(self, index: int) -> int:
         return int(self._ids[index])
 
-    def get_position(self, index: int) -> np.array:
+    def get_position(self, index: int) -> np.ndarray:
         return self._positions[index]
 
-    def get_forward(self, index: int) -> np.array:
+    def get_forward(self, index: int) -> np.ndarray:
         return self._forwards[index]
 
-    def get_rotation(self, index: int) -> np.array:
+    def get_rotation(self, index: int) -> np.ndarray:
         return self._rotations[index]
 
-    def get_euler_angles(self, index: int) -> np.array:
+    def get_euler_angles(self, index: int) -> np.ndarray:
         return self._euler_angles[index]
 
 
@@ -1421,10 +1421,10 @@ class ObiParticles(OutputData):
     def get_num_solvers(self) -> int:
         return self.data.SolversLength()
 
-    def get_positions(self, index: int) -> np.array:
+    def get_positions(self, index: int) -> np.ndarray:
         return self.data.Solvers(index).PositionsAsNumpy()
 
-    def get_velocities(self, index: int) -> np.array:
+    def get_velocities(self, index: int) -> np.ndarray:
         return self.data.Solvers(index).VelocitiesAsNumpy()
 
     def get_num_objects(self) -> int:
@@ -1439,22 +1439,22 @@ class ObiParticles(OutputData):
     def get_count(self, index: int) -> int:
         return self.data.Actors(index).Count()
 
-    def get_solver_indices(self, index: int) -> np.array:
+    def get_solver_indices(self, index: int) -> np.ndarray:
         return self.data.Actors(index).SolverIndicesAsNumpy()
 
 
 class Mouse(OutputData):
     def __init__(self, b):
         super().__init__(b)
-        self._buttons: np.array = self.data.ButtonsAsNumpy().reshape(3, 3)
+        self._buttons: np.ndarray = self.data.ButtonsAsNumpy().reshape(3, 3)
 
     def get_data(self) -> Mous.Mouse:
         return Mous.Mouse.GetRootAsMouse(self.bytes, 0)
 
-    def get_position(self) -> np.array:
+    def get_position(self) -> np.ndarray:
         return self.data.PositionAsNumpy()
 
-    def get_scroll_delta(self) -> np.array:
+    def get_scroll_delta(self) -> np.ndarray:
         return self.data.ScrollDeltaAsNumpy()
 
     def get_is_left_button_pressed(self) -> bool:

--- a/Python/tdw/physics_audio/base64_sound.py
+++ b/Python/tdw/physics_audio/base64_sound.py
@@ -11,7 +11,7 @@ class Base64Sound:
     A sound encoded as a base64 string.
     """
 
-    def __init__(self, snd: np.array):
+    def __init__(self, snd: np.ndarray):
         """
         :param snd: The sound byte array.
         """

--- a/Python/tdw/physics_audio/collision_audio_event.py
+++ b/Python/tdw/physics_audio/collision_audio_event.py
@@ -66,7 +66,7 @@ class CollisionAudioEvent:
         """:field
         The velocity vector.
         """
-        self.velocity: np.array = np.array([0, 0, 0])
+        self.velocity: np.ndarray = np.array([0, 0, 0])
         if collision.state == "exit":
             return
 

--- a/Python/tdw/physics_audio/modes.py
+++ b/Python/tdw/physics_audio/modes.py
@@ -7,7 +7,7 @@ class Modes:
     Resonant mode properties: Frequencies, powers, and times.
     """
 
-    def __init__(self, frequencies: np.array, powers: np.array, decay_times: np.array):
+    def __init__(self, frequencies: np.ndarray, powers: np.ndarray, decay_times: np.ndarray):
         """
         :param frequencies: A numpy array of mode frequencies in Hz.
         :param powers: A numpy array of mode onset powers in dB re 1.
@@ -17,17 +17,17 @@ class Modes:
         """:field
         A numpy array of mode frequencies in Hz.
         """
-        self.frequencies: np.array = frequencies
+        self.frequencies: np.ndarray = frequencies
         """:field
         A numpy array of mode onset powers in dB re 1.
         """
-        self.powers: np.array = powers
+        self.powers: np.ndarray = powers
         """:field
         A numpy array of mode decay times i.e. the time in ms it takes for each mode to decay 60dB from its onset power.
         """
-        self.decay_times: np.array = decay_times
+        self.decay_times: np.ndarray = decay_times
 
-    def sum_modes(self, fs: int = 44100, resonance: float = 1.0) -> np.array:
+    def sum_modes(self, fs: int = 44100, resonance: float = 1.0) -> np.ndarray:
         """
         Create mode time-series from mode properties and sum them together.
 
@@ -37,7 +37,7 @@ class Modes:
         :return A synthesized sound.
         """
 
-        synth_sound: np.array = np.empty
+        synth_sound: np.ndarray = np.empty
         # Scroll through modes.
         for i in range(len(self.frequencies)):
             H_dB = 80 + self.powers[i]
@@ -61,7 +61,7 @@ class Modes:
         return synth_sound
 
     @staticmethod
-    def mode_add(a: np.array, b: np.array) -> np.array:
+    def mode_add(a: np.ndarray, b: np.ndarray) -> np.ndarray:
         """
         Add together numpy arrays of different lengths by zero-padding the shorter.
 

--- a/Python/tdw/proc_gen/arrangements/arrangement.py
+++ b/Python/tdw/proc_gen/arrangements/arrangement.py
@@ -106,16 +106,11 @@ class Arrangement(ABC):
         """
 
         commands = []
-        # Get numpy array and dictionary representations of the center position.
-        if isinstance(position, dict):
-            center_dict = position
-        else:
-            center_dict = TDWUtils.array_to_vector3(position)
         # Get the x, z positions.
-        xs: np.array = np.arange(cell_size, size[0] - cell_size, cell_size)
-        zs: np.array = np.arange(cell_size, size[1] - cell_size, cell_size)
+        xs: np.ndarray = np.arange(cell_size, size[0] - cell_size, cell_size)
+        zs: np.ndarray = np.arange(cell_size, size[1] - cell_size, cell_size)
         # Get the occupancy map.
-        occupancy_map: np.array = np.zeros(shape=(len(xs), len(zs)), dtype=bool)
+        occupancy_map: np.ndarray = np.zeros(shape=(len(xs), len(zs)), dtype=bool)
         # Get the semi-minor axis of the rectangle's size.
         semi_minor_axis = size[0] if size[0] < size[1] else size[1]
         # Get valid objects.
@@ -170,8 +165,8 @@ class Arrangement(ABC):
             z = (iz * cell_size) + self._rng.uniform(-cell_size * perturbation_distance,
                                                      cell_size * perturbation_distance)
             # Offset from the center.
-            x += center_dict["x"] - size[0] / 2 + cell_size
-            z += center_dict["z"] - size[1] / 2 + cell_size
+            x += position["x"] - size[0] / 2 + cell_size
+            z += position["z"] - size[1] / 2 + cell_size
             # Cache the object ID.
             object_id = Controller.get_unique_id()
             # Set the rotation.
@@ -179,7 +174,7 @@ class Arrangement(ABC):
             self.object_ids.append(object_id)
             # Add the object.
             commands.extend(Controller.get_add_physics_object(model_name=model_name,
-                                                              position={"x": x, "y": center_dict["y"], "z": z},
+                                                              position={"x": x, "y": position["y"], "z": z},
                                                               rotation={"x": 0, "y": self._rng.uniform(0, 360), "z": 0},
                                                               object_id=object_id,
                                                               library="models_core.json"))

--- a/Python/tdw/proc_gen/arrangements/table_and_chairs.py
+++ b/Python/tdw/proc_gen/arrangements/table_and_chairs.py
@@ -44,7 +44,7 @@ class TableAndChairs(ArrangementWithRootObject, ABC):
 
         self._used_walls: int = used_walls
         self._region: InteriorRegion = region
-        self._bound_point_positions: List[np.array] = list()
+        self._bound_point_positions: List[np.ndarray] = list()
         super().__init__(model=model, position=position, rng=rng)
 
     def get_commands(self) -> List[dict]:
@@ -129,7 +129,7 @@ class TableAndChairs(ArrangementWithRootObject, ABC):
         raise Exception()
 
     @final
-    def _get_chair_bound_position(self, cardinal_direction: CardinalDirection) -> np.array:
+    def _get_chair_bound_position(self, cardinal_direction: CardinalDirection) -> np.ndarray:
         """
         :param cardinal_direction: The direction of the chair from the center of the table.
 
@@ -149,7 +149,7 @@ class TableAndChairs(ArrangementWithRootObject, ABC):
                          self._record.bounds[side]["z"] + self._position["z"]])
 
     @final
-    def _get_chair_position(self, chair_record: ModelRecord, table_bound_point: np.array) -> np.array:
+    def _get_chair_position(self, chair_record: ModelRecord, table_bound_point: np.ndarray) -> np.ndarray:
         """
         :param chair_record: The chair model record.
         :param table_bound_point: The bounds position.

--- a/Python/tdw/quaternion_utils.py
+++ b/Python/tdw/quaternion_utils.py
@@ -235,6 +235,6 @@ class QuaternionUtils:
         target_direction = target - origin
         # Normalize the heading.
         target_direction = target_direction / np.linalg.norm(target_direction)
-        perpendicular: np.array = np.cross(forward, target_direction)
+        perpendicular: np.ndarray = np.cross(forward, target_direction)
         direction = np.dot(perpendicular, QuaternionUtils.UP)
         return direction > 0

--- a/Python/tdw/replicant/actions/look_at.py
+++ b/Python/tdw/replicant/actions/look_at.py
@@ -1,6 +1,7 @@
-from typing import List, Dict, Union
+from typing import List
 import numpy as np
 from tdw.tdw_utils import TDWUtils
+from tdw.type_aliases import TARGET
 from tdw.replicant.replicant_static import ReplicantStatic
 from tdw.replicant.replicant_dynamic import ReplicantDynamic
 from tdw.replicant.actions.head_motion import HeadMotion
@@ -14,7 +15,7 @@ class LookAt(HeadMotion):
     The head will continuously move over multiple `communicate()` calls until it is looking at the target.
     """
 
-    def __init__(self, target: Union[int, np.ndarray, Dict[str,  float]], duration: float, scale_duration: bool):
+    def __init__(self, target: TARGET, duration: float, scale_duration: bool):
         """
         :param target: The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array.
         :param duration: The duration of the motion in seconds.
@@ -25,7 +26,7 @@ class LookAt(HeadMotion):
         """:field
         The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array.
         """
-        self.target: Union[int, np.ndarray, Dict[str,  float]] = target
+        self.target: TARGET = target
 
     def get_initialization_commands(self, resp: List[bytes], static: ReplicantStatic, dynamic: ReplicantDynamic,
                                     image_frequency: ImageFrequency) -> List[dict]:

--- a/Python/tdw/replicant/actions/move_to.py
+++ b/Python/tdw/replicant/actions/move_to.py
@@ -31,9 +31,9 @@ class MoveTo(Action):
     - If the Replicant takes too long to reach the target distance, the action ends in failure (see `self.max_walk_cycles`).
     """
 
-    def __init__(self, target: TARGET, collision_detection: CollisionDetection,
-                 previous: Optional[Action], reset_arms: bool, reset_arms_duration: float,
-                 scale_reset_arms_duration: bool, arrived_at: float, max_walk_cycles: int, bounds_position: str):
+    def __init__(self, target: TARGET, collision_detection: CollisionDetection, previous: Optional[Action],
+                 reset_arms: bool, reset_arms_duration: float, scale_reset_arms_duration: bool, arrived_at: float,
+                 max_walk_cycles: int, bounds_position: str):
         """
         :param target: The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array.
         :param collision_detection: The [`CollisionDetection`](../collision_detection.md) rules.

--- a/Python/tdw/replicant/actions/move_to.py
+++ b/Python/tdw/replicant/actions/move_to.py
@@ -1,6 +1,7 @@
-from typing import Union, Dict, List, Optional
+from typing import List, Optional
 import numpy as np
 from tdw.tdw_utils import TDWUtils
+from tdw.type_aliases import TARGET
 from tdw.output_data import OutputData, Bounds
 from tdw.replicant.actions.action import Action
 from tdw.replicant.actions.turn_to import TurnTo
@@ -30,7 +31,7 @@ class MoveTo(Action):
     - If the Replicant takes too long to reach the target distance, the action ends in failure (see `self.max_walk_cycles`).
     """
 
-    def __init__(self, target: Union[int, Dict[str, float], np.ndarray], collision_detection: CollisionDetection,
+    def __init__(self, target: TARGET, collision_detection: CollisionDetection,
                  previous: Optional[Action], reset_arms: bool, reset_arms_duration: float,
                  scale_reset_arms_duration: bool, arrived_at: float, max_walk_cycles: int, bounds_position: str):
         """
@@ -48,7 +49,7 @@ class MoveTo(Action):
         """:field
         The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array.
         """
-        self.target: Union[int, Dict[str, float], np.ndarray] = target
+        self.target: TARGET = target
         """:field
         The [`CollisionDetection`](../collision_detection.md) rules.
         """

--- a/Python/tdw/replicant/actions/reach_for.py
+++ b/Python/tdw/replicant/actions/reach_for.py
@@ -1,5 +1,6 @@
-from typing import List, Dict, Union, Optional
+from typing import List, Dict, Optional
 import numpy as np
+from tdw.type_aliases import TARGET
 from tdw.tdw_utils import TDWUtils
 from tdw.replicant.replicant_static import ReplicantStatic
 from tdw.replicant.replicant_dynamic import ReplicantDynamic
@@ -28,7 +29,7 @@ class ReachFor(ArmMotion):
     See also: [`ReachForWithPlan`](reach_for_with_plan.md).
     """
 
-    def __init__(self, target: Union[int, np.ndarray, Dict[str,  float]], absolute: bool, offhand_follows: bool,
+    def __init__(self, target: TARGET, absolute: bool, offhand_follows: bool,
                  arrived_at: float, max_distance: float, arms: List[Arm], dynamic: ReplicantDynamic,
                  collision_detection: CollisionDetection, previous: Optional[Action], duration: float,
                  scale_duration: bool, from_held: bool, held_point: str):
@@ -53,7 +54,7 @@ class ReachFor(ArmMotion):
         """:field
         The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array.
         """
-        self.target: Union[int, np.ndarray, Dict[str,  float]] = target
+        self.target: TARGET = target
         """:field
         If True, the target position is in world space coordinates. If False, the target position is relative to the Replicant. Ignored if `target` is an int.
         """

--- a/Python/tdw/replicant/actions/reach_for_with_plan.py
+++ b/Python/tdw/replicant/actions/reach_for_with_plan.py
@@ -1,5 +1,5 @@
-from typing import List, Dict, Union, Optional
-import numpy as np
+from typing import List, Optional
+from tdw.type_aliases import TARGET
 from tdw.replicant.replicant_static import ReplicantStatic
 from tdw.replicant.replicant_dynamic import ReplicantDynamic
 from tdw.replicant.image_frequency import ImageFrequency
@@ -40,7 +40,7 @@ class ReachForWithPlan(Action):
     See also: [`ReachFor`](reach_for.md).
     """
 
-    def __init__(self, plan: IkPlanType, target: Union[int, np.ndarray, Dict[str,  float]], absolute: bool,
+    def __init__(self, plan: IkPlanType, target: TARGET, absolute: bool,
                  arrived_at: float, max_distance: float, arm: Arm, dynamic: ReplicantDynamic,
                  collision_detection: CollisionDetection, previous: Optional[Action], duration: float,
                  scale_duration: bool, from_held: bool, held_point: str):

--- a/Python/tdw/replicant/actions/reach_for_with_plan.py
+++ b/Python/tdw/replicant/actions/reach_for_with_plan.py
@@ -40,10 +40,9 @@ class ReachForWithPlan(Action):
     See also: [`ReachFor`](reach_for.md).
     """
 
-    def __init__(self, plan: IkPlanType, target: TARGET, absolute: bool,
-                 arrived_at: float, max_distance: float, arm: Arm, dynamic: ReplicantDynamic,
-                 collision_detection: CollisionDetection, previous: Optional[Action], duration: float,
-                 scale_duration: bool, from_held: bool, held_point: str):
+    def __init__(self, plan: IkPlanType, target: TARGET, absolute: bool, arrived_at: float, max_distance: float,
+                 arm: Arm, dynamic: ReplicantDynamic, collision_detection: CollisionDetection,
+                 previous: Optional[Action], duration: float, scale_duration: bool, from_held: bool, held_point: str):
         """
         :param plan: An [`IkPlanType`](../ik_plans/ik_plan_type.md) that will define the [`IkPlan`](../ik_plans/ik_plan.md) this action will use.
         :param target: The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array.

--- a/Python/tdw/replicant/actions/turn_to.py
+++ b/Python/tdw/replicant/actions/turn_to.py
@@ -1,5 +1,6 @@
-from typing import Union, Dict, List
+from typing import List
 import numpy as np
+from tdw.type_aliases import TARGET
 from tdw.tdw_utils import TDWUtils
 from tdw.replicant.actions.action import Action
 from tdw.replicant.action_status import ActionStatus
@@ -15,13 +16,13 @@ class TurnTo(Action):
     This is a non-animated action, meaning that the Replicant will immediately snap to the angle.
     """
 
-    def __init__(self, target: Union[int, Dict[str, float], np.ndarray]):
+    def __init__(self, target: TARGET):
         """
         :param target: The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array.
         """
 
         super().__init__()
-        self._target: Union[int, Dict[str, float], np.ndarray] = target
+        self._target: TARGET = target
 
     def get_initialization_commands(self, resp: List[bytes], static: ReplicantStatic, dynamic: ReplicantDynamic,
                                     image_frequency: ImageFrequency) -> List[dict]:

--- a/Python/tdw/replicant/ik_plans/ik_plan.py
+++ b/Python/tdw/replicant/ik_plans/ik_plan.py
@@ -25,9 +25,9 @@ class IkPlan(ABC):
     An `IkPlan` is used by the [`ReachForWithPlan`](../actions/reach_for_with_plan.md) action. (From the Replicant API, this is combined with the `reach_for(target, arm)` function).
     """
 
-    def __init__(self, target: TARGET, absolute: bool, arrived_at: float,
-                 max_distance: float, arm: Arm, dynamic: ReplicantDynamic, collision_detection: CollisionDetection,
-                 previous: Optional[Action], duration: float, scale_duration: bool, from_held: bool, held_point: str):
+    def __init__(self, target: TARGET, absolute: bool, arrived_at: float, max_distance: float, arm: Arm,
+                 dynamic: ReplicantDynamic, collision_detection: CollisionDetection, previous: Optional[Action],
+                 duration: float, scale_duration: bool, from_held: bool, held_point: str):
         """
         :param target: The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array.
         :param absolute: If True, the target position is in world space coordinates. If False, the target position is relative to the Replicant. Ignored if `target` is an int.

--- a/Python/tdw/replicant/ik_plans/ik_plan.py
+++ b/Python/tdw/replicant/ik_plans/ik_plan.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
-from typing import List, Dict, Union, Optional
+from typing import List, Optional
 from overrides import final
-import numpy as np
+from tdw.type_aliases import TARGET
 from tdw.replicant.replicant_static import ReplicantStatic
 from tdw.replicant.replicant_dynamic import ReplicantDynamic
 from tdw.replicant.actions.arm_motion import ArmMotion
@@ -25,7 +25,7 @@ class IkPlan(ABC):
     An `IkPlan` is used by the [`ReachForWithPlan`](../actions/reach_for_with_plan.md) action. (From the Replicant API, this is combined with the `reach_for(target, arm)` function).
     """
 
-    def __init__(self, target: Union[int, np.ndarray, Dict[str,  float]], absolute: bool, arrived_at: float,
+    def __init__(self, target: TARGET, absolute: bool, arrived_at: float,
                  max_distance: float, arm: Arm, dynamic: ReplicantDynamic, collision_detection: CollisionDetection,
                  previous: Optional[Action], duration: float, scale_duration: bool, from_held: bool, held_point: str):
         """
@@ -73,7 +73,7 @@ class IkPlan(ABC):
         """:field
         The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array.
         """
-        self.target: Union[int, np.ndarray, Dict[str,  float]] = target
+        self.target: TARGET = target
         """:field
         If True, the target position is in world space coordinates. If False, the target position is relative to the Replicant. Ignored if `target` is an int.
         """
@@ -108,7 +108,7 @@ class IkPlan(ABC):
         raise Exception()
 
     @final
-    def _get_reach_for(self, target: Union[int, np.ndarray, Dict[str,  float]], absolute: bool,
+    def _get_reach_for(self, target: TARGET, absolute: bool,
                        duration: float, dynamic: ReplicantDynamic, from_held: bool) -> ReachFor:
         """
         :param target: The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array.

--- a/Python/tdw/robot_data/joint_dynamic.py
+++ b/Python/tdw/robot_data/joint_dynamic.py
@@ -6,7 +6,7 @@ class JointDynamic:
     Dynamic info for a joint that can change per-frame, such as its current position.
     """
 
-    def __init__(self, joint_id: int, position: np.array, angles: np.array, moving: bool):
+    def __init__(self, joint_id: int, position: np.ndarray, angles: np.ndarray, moving: bool):
         """
         :param joint_id: The ID of this joint.
         :param position: The worldspace position of this joint as an `[x, y, z]` numpy array.
@@ -21,11 +21,11 @@ class JointDynamic:
         """:field
         The worldspace position of this joint as an `[x, y, z]` numpy array.
         """
-        self.position: np.array = position
+        self.position: np.ndarray = position
         """:field
         The angles of each axis of the joint in degrees. For prismatic joints, you need to convert this from degrees to radians in order to get the correct distance in meters.
         """
-        self.angles: np.array = angles
+        self.angles: np.ndarray = angles
         """:field
         If True, this joint is currently moving.
         """

--- a/Python/tdw/robot_data/joint_static.py
+++ b/Python/tdw/robot_data/joint_static.py
@@ -32,7 +32,7 @@ class JointStatic:
         """:field
         The segmentation color of this joint as an `[r, g, b]` numpy array.
         """
-        self.segmentation_color: np.array = np.array(static_robot.get_joint_segmentation_color(static_index))
+        self.segmentation_color: np.ndarray = np.array(static_robot.get_joint_segmentation_color(static_index))
         """:field
         The mass of this joint.
         """

--- a/Python/tdw/robot_data/non_moving.py
+++ b/Python/tdw/robot_data/non_moving.py
@@ -24,4 +24,4 @@ class NonMoving:
         """:field
         The segmentation color of this joint as an `[r, g, b]` numpy array.
         """
-        self.segmentation_color: np.array = np.array(static_robot.get_non_moving_segmentation_color(index))
+        self.segmentation_color: np.ndarray = np.array(static_robot.get_non_moving_segmentation_color(index))

--- a/Python/tdw/tdw_utils.py
+++ b/Python/tdw/tdw_utils.py
@@ -619,13 +619,13 @@ class TDWUtils:
         :return: A dictionary of the bounds. Key = the name of the position. Value = the position as a numpy array.
         """
 
-        return {"top": np.array(bounds.get_top(index)),
-                "bottom": np.array(bounds.get_bottom(index)),
-                "left": np.array(bounds.get_left(index)),
-                "right": np.array(bounds.get_right(index)),
-                "front": np.array(bounds.get_front(index)),
-                "back": np.array(bounds.get_back(index)),
-                "center": np.array(bounds.get_center(index))}
+        return {"top": np.ndarray(bounds.get_top(index)),
+                "bottom": np.ndarray(bounds.get_bottom(index)),
+                "left": np.ndarray(bounds.get_left(index)),
+                "right": np.ndarray(bounds.get_right(index)),
+                "front": np.ndarray(bounds.get_front(index)),
+                "back": np.ndarray(bounds.get_back(index)),
+                "center": np.ndarray(bounds.get_center(index))}
 
     @staticmethod
     def get_bounds_extents(bounds: Union[Bounds, Dict[str, Dict[str, float]]], index: int = 0) -> np.ndarray:

--- a/Python/tdw/tdw_utils.py
+++ b/Python/tdw/tdw_utils.py
@@ -450,7 +450,7 @@ class TDWUtils:
         """
 
         if isinstance(camera_matrix, tuple):
-            camera_matrix = np.ndarray(camera_matrix)
+            camera_matrix = np.array(camera_matrix)
         camera_matrix = np.linalg.inv(camera_matrix.reshape((4, 4)))
 
         # Different from real-world camera coordinate system.
@@ -619,13 +619,13 @@ class TDWUtils:
         :return: A dictionary of the bounds. Key = the name of the position. Value = the position as a numpy array.
         """
 
-        return {"top": np.ndarray(bounds.get_top(index)),
-                "bottom": np.ndarray(bounds.get_bottom(index)),
-                "left": np.ndarray(bounds.get_left(index)),
-                "right": np.ndarray(bounds.get_right(index)),
-                "front": np.ndarray(bounds.get_front(index)),
-                "back": np.ndarray(bounds.get_back(index)),
-                "center": np.ndarray(bounds.get_center(index))}
+        return {"top": bounds.get_top(index),
+                "bottom": bounds.get_bottom(index),
+                "left": bounds.get_left(index),
+                "right": bounds.get_right(index),
+                "front": bounds.get_front(index),
+                "back": bounds.get_back(index),
+                "center": bounds.get_center(index)}
 
     @staticmethod
     def get_bounds_extents(bounds: Union[Bounds, Dict[str, Dict[str, float]]], index: int = 0) -> np.ndarray:
@@ -637,9 +637,9 @@ class TDWUtils:
         """
 
         if isinstance(bounds, Bounds):
-            return np.array([np.linalg.norm(np.array(bounds.get_left(index)) - np.array(bounds.get_right(index))),
-                             np.linalg.norm(np.array(bounds.get_top(index)) - np.array(bounds.get_bottom(index))),
-                             np.linalg.norm(np.array(bounds.get_front(index)) - np.array(bounds.get_back(index)))])
+            return np.array([np.linalg.norm(bounds.get_left(index) - bounds.get_right(index)),
+                             np.linalg.norm(bounds.get_top(index) - bounds.get_bottom(index)),
+                             np.linalg.norm(bounds.get_front(index) - bounds.get_back(index))])
         elif isinstance(bounds, dict):
             return np.array([np.linalg.norm(TDWUtils.vector3_to_array(bounds["left"]) - TDWUtils.vector3_to_array(bounds["right"])),
                              np.linalg.norm(TDWUtils.vector3_to_array(bounds["top"]) - TDWUtils.vector3_to_array(bounds["bottom"])),

--- a/Python/tdw/type_aliases.py
+++ b/Python/tdw/type_aliases.py
@@ -1,0 +1,8 @@
+from typing import Union, Dict
+import numpy as np
+
+# A target position or object: an integer (an object ID), a numpy array (a position), or a dictionary (a position).
+TARGET = Union[int, np.ndarray, Dict[str,  float]]
+
+# A target position: A numpy array or a dictionary.
+POSITION = Union[np.ndarray, Dict[str, float]]

--- a/Python/tdw/type_aliases.py
+++ b/Python/tdw/type_aliases.py
@@ -4,5 +4,8 @@ import numpy as np
 # A target position or object: an integer (an object ID), a numpy array (a position), or a dictionary (a position).
 TARGET = Union[int, np.ndarray, Dict[str,  float]]
 
-# A target position: A numpy array or a dictionary.
+# A position: A numpy array or a dictionary.
 POSITION = Union[np.ndarray, Dict[str, float]]
+
+# A position: A numpy array or a dictionary.
+ROTATION = Union[np.ndarray, Dict[str, float]]

--- a/Python/tdw/type_aliases.py
+++ b/Python/tdw/type_aliases.py
@@ -7,5 +7,5 @@ TARGET = Union[int, np.ndarray, Dict[str,  float]]
 # A position: A numpy array or a dictionary.
 POSITION = Union[np.ndarray, Dict[str, float]]
 
-# A position: A numpy array or a dictionary.
+# A rotation: A numpy array or a dictionary.
 ROTATION = Union[np.ndarray, Dict[str, float]]

--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ High-level API: [tdw_physics](https://github.com/alters-mit/tdw_physics)
 - [QuaternionUtils](Documentation/python/quaternion_utils.md)
 - [RemoteBuildLauncher](Documentation/python/remote_build_launcher.md)
 - [TDWUtils](Documentation/python/tdw_utils.md)
+- [TypeAliases](Documentation/python/type_aliases.md)
 
 **tdw.add_ons**
 


### PR DESCRIPTION
### `tdw` module

- (Backend) Added `tdw.type_aliases` which contains aliases for commonly used types.
- Fixed: In many scripts, numpy array type hinting uses `np.array` instead of `np.ndarray`.