### PR TITLE
Marked composite toaster models as do_not_use

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -14,10 +14,12 @@ To upgrade from TDW v1.10 to v1.11, read [this guide](upgrade_guides/v1.10_to_v1
 
 - Fixed: `RobotCreator` can't clone a repo if the branch is named anything other than `"master"`.
 - Fixed: `FloorplanFlood` doesn't work in any `floorplan_3` scenes due to a bad key in `floorplan_floods.json`.
+- Removed from the roster of valid ProcGenKitchen models: vray_077_composite, vray_083_composite, vray_084_composite, vray_085_composite
 
 ### Model Library
 
 - Added to `models_core.json`: 104_sprite_can_12_fl_oz_vray, 699264_shoppingcart_2013, apple_ipod_touch_grey_vray, apple_ipod_touch_pink_vray, b01_bag, b02_bag, b03_backpack, b03_basket, b03_beats_solo_hd_headphone_03_2010, b03_cocacola_can_cage, b03_dollarstack, b03_shopping_cart, b03_shopping_cart_walmart, b03_shoppingcart_2013, b04_1106_backpack, b04_armani_handbag, b04_basket, b04_bottle_20ml, b04_bottle_max, b04_can, b04_cgaxis_models_31_12_vray, b04_dump, b04_money, b04_shoppping_cart, b05_shopping_cart3, b06_backpack, b06_backpack_new
+- Marked the following models as do_not_use: vray_077_composite, vray_083_composite, vray_084_composite, vray_085_composite
 
 ### Scene Library
 

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from pathlib import Path
 import re
 
-__version__ = "1.11.23.4"
+__version__ = "1.11.23.5"
 readme_path = Path('../README.md')
 if readme_path.exists():
     long_description = readme_path.read_text(encoding='utf-8')

--- a/Python/tdw/metadata_libraries/models_core.json
+++ b/Python/tdw/metadata_libraries/models_core.json
@@ -64903,6 +64903,7 @@
             "wnid": "n04442312"
         },
         "vray_077_composite": {
+            "affordance_points": [],
             "asset_bundle_sizes": {
                 "Darwin": 1891039,
                 "Linux": 2306751,
@@ -64952,8 +64953,8 @@
             },
             "composite_object": true,
             "container_shapes": [],
-            "do_not_use": false,
-            "do_not_use_reason": "",
+            "do_not_use": true,
+            "do_not_use_reason": "Incorrect configureable joint. MeshCollider group49 doesn't have a mesh.",
             "flex": false,
             "name": "vray_077_composite",
             "physics_quality": 0.9800953581862236,
@@ -65261,6 +65262,7 @@
             "wnid": "n04442312"
         },
         "vray_084_composite": {
+            "affordance_points": [],
             "asset_bundle_sizes": {
                 "Darwin": 462606,
                 "Linux": 844232,
@@ -65310,8 +65312,8 @@
             },
             "composite_object": true,
             "container_shapes": [],
-            "do_not_use": false,
-            "do_not_use_reason": "",
+            "do_not_use": true,
+            "do_not_use_reason": "Incorrect configureable joint",
             "flex": false,
             "name": "vray_084_composite",
             "physics_quality": 1.2229561250480188,
@@ -65433,6 +65435,7 @@
             "wnid": "n04442312"
         },
         "vray_085_composite": {
+            "affordance_points": [],
             "asset_bundle_sizes": {
                 "Darwin": 248359,
                 "Linux": 430490,
@@ -65482,8 +65485,8 @@
             },
             "composite_object": true,
             "container_shapes": [],
-            "do_not_use": false,
-            "do_not_use_reason": "",
+            "do_not_use": true,
+            "do_not_use_reason": "Incorrect configureable joint",
             "flex": false,
             "name": "vray_085_composite",
             "physics_quality": 1.2555309160884582,

--- a/Python/tdw/metadata_libraries/models_special.json
+++ b/Python/tdw/metadata_libraries/models_special.json
@@ -403,7 +403,7 @@
             ],
             "do_not_use": false,
             "do_not_use_reason": "",
-            "flex": true,
+            "flex": false,
             "name": "dishwasher_4_counter_top",
             "physics_quality": 0.5680550766426401,
             "scale_factor": 1,


### PR DESCRIPTION
Marked the following models as do_not_use: vray_077_composite, vray_083_composite, vray_084_composite, vray_085_composite

Report from the model verifier: 

[models_full.txt](https://github.com/threedworld-mit/tdw/files/11824871/models_full.txt)
