### PR TITLE
Added a warning about trying to run Resonance Audio on Apple Silicon

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -27,6 +27,14 @@ To upgrade from TDW v1.10 to v1.11, read [this guide](upgrade_guides/v1.10_to_v1
 - Removed `abandoned_factory` because the file size is too big to be useful (over 3 GB)
 - Removed `floorplan_3a`, `floorplan_3b`, and `floorplan_3c` because they aren't used in the `Floorplan` add-on
 
+### Documentation
+
+#### Modified Documentation
+
+| Document                           | Modification                                                 |
+| ---------------------------------- | ------------------------------------------------------------ |
+| `lessons/audio/resonance_audio.md` | Added a warning about trying to run Resonance Audio on Apple Silicon (it will crash the build). |
+
 ## v1.11.22
 
 ### Command API

--- a/Documentation/lessons/audio/resonance_audio.md
+++ b/Documentation/lessons/audio/resonance_audio.md
@@ -11,7 +11,9 @@
 
 Resonance Audio is best used with interior room environments.
 
-Resonance Audio has the same [system requirements](initialize_audio.md) as Unity's built-in audio system.
+## Requirements
+
+Resonance Audio has the same [system requirements](initialize_audio.md) as Unity's built-in audio system. **However, Resonance Audio does not work on Apple Silicon.** If you try to use Resonance Audio on a Mac with Apple Silicon, the build will crash. 
 
 ## Initialize a scene with Resonance Audio
 


### PR DESCRIPTION
Closes #598

### Documentation

#### Modified Documentation

| Document                           | Modification                                                 |
| ---------------------------------- | ------------------------------------------------------------ |
| `lessons/audio/resonance_audio.md` | Added a warning about trying to run Resonance Audio on Apple Silicon (it will crash the build). | 