### PR TITLE
Removed alcantara_microfibre_brushed_right

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -10,6 +10,10 @@ To upgrade from TDW v1.11 to v1.12, read [this guide](upgrade_guides/v1.11_to_v1
 
 - **Fixed: loading a new scene doesn't unload previous scenes.**
 
+### Material Library
+
+- Removed alcantara_microfibre_brushed_right because the `materials_med.json` version caused a crash if glass_clear was also loaded.
+
 ## v1.12.3
 
 ### New Features

--- a/Python/screenshotter.py
+++ b/Python/screenshotter.py
@@ -274,12 +274,10 @@ class MaterialScreenshotter(_Screenshotter):
         self.communicate([self.get_add_material(record.name),
                           {"$type": "set_primitive_visual_material",
                            "id": self.sphere_id,
-                           "name": record.name,
-                           "quality": "high"},
+                           "name": record.name},
                           {"$type": "set_primitive_visual_material",
                            "id": self.cube_id,
-                           "name": record.name,
-                           "quality": "high"}])
+                           "name": record.name}])
         # Capture the image the following frame to allow it to initialize correctly.
         resp = self.communicate([])
         return Images(resp[0])

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from pathlib import Path
 import re
 
-__version__ = "1.12.4.0"
+__version__ = "1.12.4.1"
 readme_path = Path('../README.md')
 if readme_path.exists():
     long_description = readme_path.read_text(encoding='utf-8')

--- a/Python/tdw/metadata_libraries/materials_high.json
+++ b/Python/tdw/metadata_libraries/materials_high.json
@@ -172,15 +172,6 @@
                 "Windows": "https://tdw-public.s3.amazonaws.com/materials_high/windows/pre-2019.2/alcantara_honeycomb_quilt"
             }
         },
-        "alcantara_microfibre_brushed_right": {
-            "name": "alcantara_microfibre_brushed_right",
-            "type": "Fabric",
-            "urls": {
-                "Darwin": "https://tdw-public.s3.amazonaws.com/materials_high/osx/pre-2019.2/alcantara_microfibre_brushed_right",
-                "Linux": "https://tdw-public.s3.amazonaws.com/materials_high/linux/pre-2019.2/alcantara_microfibre_brushed_right",
-                "Windows": "https://tdw-public.s3.amazonaws.com/materials_high/windows/pre-2019.2/alcantara_microfibre_brushed_right"
-            }
-        },
         "alcantara_microfibre_brushed_up": {
             "name": "alcantara_microfibre_brushed_up",
             "type": "Fabric",

--- a/Python/tdw/metadata_libraries/materials_low.json
+++ b/Python/tdw/metadata_libraries/materials_low.json
@@ -172,15 +172,6 @@
                 "Windows": "https://tdw-public.s3.amazonaws.com/materials_low/windows/pre-2019.2/alcantara_honeycomb_quilt"
             }
         },
-        "alcantara_microfibre_brushed_right": {
-            "name": "alcantara_microfibre_brushed_right",
-            "type": "Fabric",
-            "urls": {
-                "Darwin": "https://tdw-public.s3.amazonaws.com/materials_low/osx/pre-2019.2/alcantara_microfibre_brushed_right",
-                "Linux": "https://tdw-public.s3.amazonaws.com/materials_low/linux/pre-2019.2/alcantara_microfibre_brushed_right",
-                "Windows": "https://tdw-public.s3.amazonaws.com/materials_low/windows/pre-2019.2/alcantara_microfibre_brushed_right"
-            }
-        },
         "alcantara_microfibre_brushed_up": {
             "name": "alcantara_microfibre_brushed_up",
             "type": "Fabric",

--- a/Python/tdw/metadata_libraries/materials_med.json
+++ b/Python/tdw/metadata_libraries/materials_med.json
@@ -172,15 +172,6 @@
                 "Windows": "https://tdw-public.s3.amazonaws.com/materials_med/windows/pre-2019.2/alcantara_honeycomb_quilt"
             }
         },
-        "alcantara_microfibre_brushed_right": {
-            "name": "alcantara_microfibre_brushed_right",
-            "type": "Fabric",
-            "urls": {
-                "Darwin": "https://tdw-public.s3.amazonaws.com/materials_med/osx/pre-2019.2/alcantara_microfibre_brushed_right",
-                "Linux": "https://tdw-public.s3.amazonaws.com/materials_med/linux/pre-2019.2/alcantara_microfibre_brushed_right",
-                "Windows": "https://tdw-public.s3.amazonaws.com/materials_med/windows/pre-2019.2/alcantara_microfibre_brushed_right"
-            }
-        },
         "alcantara_microfibre_brushed_up": {
             "name": "alcantara_microfibre_brushed_up",
             "type": "Fabric",


### PR DESCRIPTION
### Material Library

- Removed alcantara_microfibre_brushed_right because the `materials_med.json` version caused a crash if glass_clear was also loaded.