### PR TITLE
Fixed: ProcGenKitchen can't create multiple rooms.

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -39,6 +39,8 @@ We achieved this by doing the following:
 
 - Fixed: `girl_casual` Replicant collision detection doesn't work. 
   - (Backend): Added new parameter `collision_avoidance_y` to each Replicant record and the `MoveBy` and `MoveTo` actions. These parameters are automatically set at runtime.
+- Removed `fridge_large_composite` as a valid refrigerator in the proc gen arrangement system because it was causing crashes.
+- Fixed: ProcGenKitchen can't create multiple rooms.
 
 ### Benchmarking
 

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from pathlib import Path
 import re
 
-__version__ = "1.12.9.1"
+__version__ = "1.12.9.2"
 readme_path = Path('../README.md')
 if readme_path.exists():
     long_description = readme_path.read_text(encoding='utf-8')

--- a/Python/tdw/add_ons/proc_gen_kitchen.py
+++ b/Python/tdw/add_ons/proc_gen_kitchen.py
@@ -305,7 +305,7 @@ class ProcGenKitchen(AddOn):
         commands.append({"$type": "step_physics",
                          "frames": 50})
         # Set the commands.
-        self.commands = commands
+        self.commands.extend(commands)
 
     def get_initialization_commands(self) -> List[dict]:
         return []

--- a/Python/tdw/proc_gen/arrangements/data/models.json
+++ b/Python/tdw/proc_gen/arrangements/data/models.json
@@ -234,8 +234,7 @@
   ],
   "refrigerator": [
     "b03_ka90ivi20r_2013__vray_composite",
-    "kenmore_refr_74049_composite",
-    "fridge_large_composite"
+    "kenmore_refr_74049_composite"
   ],
   "salt": [
     "b05_cylinder001"


### PR DESCRIPTION
### `tdw` module

- Removed `fridge_large_composite` as a valid refrigerator in the proc gen arrangement system because it was causing crashes.
- Fixed: ProcGenKitchen can't create multiple rooms.