### PR TITLE
Added optional targets parameter to set asset bundle build targets

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -25,6 +25,7 @@ To upgrade from TDW v1.11 to v1.12, read [this guide](upgrade_guides/v1.11_to_v1
 - Added two optional flags to all controllers. They only work if `launch_build=True`:
   - `--force_glcore42` Launch the build using OpenGL 4.2, which can fix some segfaults. If `launch_build=False`, you instead launch your build with a similar flag: `./TDW.x86_64 -force-glcore42`.
   - `--flip_images` to flip images if they're being saved upside-down. If `launch_build=False`, you instead launch your build with a similar flag: `./TDW.x86_64 -flip_images`.
+  - Added optional argument `targets` to each asset bundle creator (e.g. `ModelCreator`) function that creates asset bundles (e.g. `source_file_to_asset_bundles()`). If set, asset bundles for only these targets will be created. Options: `"linux"`, `"osx"`, `"windows"`, `"webgl"`. If None, defaults to `["linux", "osx", "windows"]`.
 
 ### Docker
 

--- a/Documentation/python/asset_bundle_creator/animation_creator.md
+++ b/Documentation/python/asset_bundle_creator/animation_creator.md
@@ -40,6 +40,8 @@ Create animation asset bundles from .anim or .fbx files.
 
 **`self.source_file_to_asset_bundles(name, source_file, output_directory)`**
 
+**`self.source_file_to_asset_bundles(name, source_file, output_directory, targets=None)`**
+
 Convert a source file into 3 asset bundle files (Windows, OS X, and Linux).
 
 | Parameter | Type | Default | Description |
@@ -47,12 +49,13 @@ Convert a source file into 3 asset bundle files (Windows, OS X, and Linux).
 | name |  str |  | The name of the animation. |
 | source_file |  Union[str, Path] |  | The path to the source file as a string or [`Path`](https://docs.python.org/3/library/pathlib.html). |
 | output_directory |  Union[str, Path] |  | The root output directory as a string or [`Path`](https://docs.python.org/3/library/pathlib.html). If this directory doesn't exist, it will be created. |
+| targets |  List[str] | None | A list of build targets. Options: "linux", "osx", "windows", "webgl". If None, defaults to `["linux", "osx", "windows"]`. |
 
 #### source_directory_to_asset_bundles
 
 **`self.source_directory_to_asset_bundles(source_directory, output_directory)`**
 
-**`self.source_directory_to_asset_bundles(source_directory, output_directory, library_description=None, overwrite=False, continue_on_error=True, search_pattern=None, cleanup=True)`**
+**`self.source_directory_to_asset_bundles(source_directory, output_directory, library_description=None, overwrite=False, continue_on_error=True, search_pattern=None, cleanup=True, targets=None)`**
 
 Convert a directory of source files to asset bundles.
 
@@ -67,6 +70,7 @@ Calling this is *significantly* faster than calling `self.source_file_to_asset_b
 | continue_on_error |  bool  | True | If True, continue generating asset bundles even if there is a problem with one file. If False, stop the process if there's an error. |
 | search_pattern |  str  | None | A search pattern for files, for example `"*.fbx"`. All subdirectories will be recursively searched. |
 | cleanup |  bool  | True | If True, delete intermediary files such as the prefabs in the `asset_bundle_creator` Unity Editor project. |
+| targets |  List[str] | None | A list of build targets. Options: "linux", "osx", "windows", "webgl". If None, defaults to `["linux", "osx", "windows"]`. |
 
 #### get_base_unity_call
 
@@ -92,6 +96,8 @@ Execute a call to Unity Editor. If `self.quiet == False` this will continuously 
 #### prefab_to_asset_bundles
 
 **`self.prefab_to_asset_bundles(name, output_directory)`**
+
+**`self.prefab_to_asset_bundles(name, output_directory, targets=None)`**
 
 Build asset bundles from a .prefab file. This is useful when you want to edit the .prefab file by hand, e.g.:
 
@@ -130,6 +136,7 @@ output_directory/
 | --- | --- | --- | --- |
 | name |  str |  | The name of the model (the name of the .prefab file, minus the extension). |
 | output_directory |  Union[str, Path] |  | The root output directory as a string or [`Path`](https://docs.python.org/3/library/pathlib.html). If this directory doesn't exist, it will be created. |
+| targets |  List[str] | None | A list of build targets. Options: "linux", "osx", "windows", "webgl". If None, defaults to `["linux", "osx", "windows"]`. |
 
 #### cleanup
 

--- a/Documentation/python/asset_bundle_creator/asset_bundle_creator.md
+++ b/Documentation/python/asset_bundle_creator/asset_bundle_creator.md
@@ -61,6 +61,8 @@ Execute a call to Unity Editor. If `self.quiet == False` this will continuously 
 
 **`self.prefab_to_asset_bundles(name, output_directory)`**
 
+**`self.prefab_to_asset_bundles(name, output_directory, targets=None)`**
+
 Build asset bundles from a .prefab file. This is useful when you want to edit the .prefab file by hand, e.g.:
 
 1. `self.source_file_to_prefab()`
@@ -98,6 +100,7 @@ output_directory/
 | --- | --- | --- | --- |
 | name |  str |  | The name of the model (the name of the .prefab file, minus the extension). |
 | output_directory |  Union[str, Path] |  | The root output directory as a string or [`Path`](https://docs.python.org/3/library/pathlib.html). If this directory doesn't exist, it will be created. |
+| targets |  List[str] | None | A list of build targets. Options: "linux", "osx", "windows", "webgl". If None, defaults to `["linux", "osx", "windows"]`. |
 
 #### cleanup
 

--- a/Documentation/python/asset_bundle_creator/composite_object_creator.md
+++ b/Documentation/python/asset_bundle_creator/composite_object_creator.md
@@ -65,6 +65,8 @@ Execute a call to Unity Editor. If `self.quiet == False` this will continuously 
 
 **`self.prefab_to_asset_bundles(name, output_directory)`**
 
+**`self.prefab_to_asset_bundles(name, output_directory, targets=None)`**
+
 Build asset bundles from a .prefab file. This is useful when you want to edit the .prefab file by hand, e.g.:
 
 1. `self.source_file_to_prefab()`
@@ -102,6 +104,7 @@ output_directory/
 | --- | --- | --- | --- |
 | name |  str |  | The name of the model (the name of the .prefab file, minus the extension). |
 | output_directory |  Union[str, Path] |  | The root output directory as a string or [`Path`](https://docs.python.org/3/library/pathlib.html). If this directory doesn't exist, it will be created. |
+| targets |  List[str] | None | A list of build targets. Options: "linux", "osx", "windows", "webgl". If None, defaults to `["linux", "osx", "windows"]`. |
 
 #### cleanup
 
@@ -149,7 +152,7 @@ _Returns:_  The name of the Unity C# class, e.g. `ModelCreator`.
 
 **`self.source_file_to_asset_bundles(name, source_file, output_directory)`**
 
-**`self.source_file_to_asset_bundles(name, source_file, output_directory, vhacd_resolution=800000, wnid=None, wcategory=None, cleanup=True)`**
+**`self.source_file_to_asset_bundles(name, source_file, output_directory, vhacd_resolution=800000, wnid=None, wcategory=None, cleanup=True, targets=None)`**
 
 Convert a source .urdf file into 3 asset bundle files (Windows, OS X, and Linux).
 
@@ -196,6 +199,7 @@ output_directory/
 | wnid |  str  | None | The WordNet ID of the model. Can be None. |
 | wcategory |  str  | None | The WordNet category of the model. Can be None. |
 | cleanup |  bool  | True | If True, delete intermediary files such as the prefab in the `asset_bundle_creator` Unity Editor project. |
+| targets |  List[str] | None | A list of build targets. Options: "linux", "osx", "windows", "webgl". If None, defaults to `["linux", "osx", "windows"]`. |
 
 #### source_file_to_prefab
 

--- a/Documentation/python/asset_bundle_creator/humanoid_creator.md
+++ b/Documentation/python/asset_bundle_creator/humanoid_creator.md
@@ -40,6 +40,8 @@ Create asset bundles of non-physics humanoids from .fbx files.
 
 **`self.source_file_to_asset_bundles(name, source_file, output_directory)`**
 
+**`self.source_file_to_asset_bundles(name, source_file, output_directory, targets=None)`**
+
 Convert a source file into 3 asset bundle files (Windows, OS X, and Linux).
 
 | Parameter | Type | Default | Description |
@@ -47,12 +49,13 @@ Convert a source file into 3 asset bundle files (Windows, OS X, and Linux).
 | name |  str |  | The name of the animation. |
 | source_file |  Union[str, Path] |  | The path to the source file as a string or [`Path`](https://docs.python.org/3/library/pathlib.html). |
 | output_directory |  Union[str, Path] |  | The root output directory as a string or [`Path`](https://docs.python.org/3/library/pathlib.html). If this directory doesn't exist, it will be created. |
+| targets |  List[str] | None | A list of build targets. Options: "linux", "osx", "windows", "webgl". If None, defaults to `["linux", "osx", "windows"]`. |
 
 #### source_directory_to_asset_bundles
 
 **`self.source_directory_to_asset_bundles(source_directory, output_directory)`**
 
-**`self.source_directory_to_asset_bundles(source_directory, output_directory, library_description=None, overwrite=False, continue_on_error=True, search_pattern=None, cleanup=True)`**
+**`self.source_directory_to_asset_bundles(source_directory, output_directory, library_description=None, overwrite=False, continue_on_error=True, search_pattern=None, cleanup=True, targets=None)`**
 
 Convert a directory of source files to asset bundles.
 
@@ -67,6 +70,7 @@ Calling this is *significantly* faster than calling `self.source_file_to_asset_b
 | continue_on_error |  bool  | True | If True, continue generating asset bundles even if there is a problem with one file. If False, stop the process if there's an error. |
 | search_pattern |  str  | None | A search pattern for files, for example `"*.fbx"`. All subdirectories will be recursively searched. |
 | cleanup |  bool  | True | If True, delete intermediary files such as the prefabs in the `asset_bundle_creator` Unity Editor project. |
+| targets |  List[str] | None | A list of build targets. Options: "linux", "osx", "windows", "webgl". If None, defaults to `["linux", "osx", "windows"]`. |
 
 #### get_base_unity_call
 
@@ -92,6 +96,8 @@ Execute a call to Unity Editor. If `self.quiet == False` this will continuously 
 #### prefab_to_asset_bundles
 
 **`self.prefab_to_asset_bundles(name, output_directory)`**
+
+**`self.prefab_to_asset_bundles(name, output_directory, targets=None)`**
 
 Build asset bundles from a .prefab file. This is useful when you want to edit the .prefab file by hand, e.g.:
 
@@ -130,6 +136,7 @@ output_directory/
 | --- | --- | --- | --- |
 | name |  str |  | The name of the model (the name of the .prefab file, minus the extension). |
 | output_directory |  Union[str, Path] |  | The root output directory as a string or [`Path`](https://docs.python.org/3/library/pathlib.html). If this directory doesn't exist, it will be created. |
+| targets |  List[str] | None | A list of build targets. Options: "linux", "osx", "windows", "webgl". If None, defaults to `["linux", "osx", "windows"]`. |
 
 #### cleanup
 

--- a/Documentation/python/asset_bundle_creator/humanoid_creator_base.md
+++ b/Documentation/python/asset_bundle_creator/humanoid_creator_base.md
@@ -61,6 +61,8 @@ Execute a call to Unity Editor. If `self.quiet == False` this will continuously 
 
 **`self.prefab_to_asset_bundles(name, output_directory)`**
 
+**`self.prefab_to_asset_bundles(name, output_directory, targets=None)`**
+
 Build asset bundles from a .prefab file. This is useful when you want to edit the .prefab file by hand, e.g.:
 
 1. `self.source_file_to_prefab()`
@@ -98,6 +100,7 @@ output_directory/
 | --- | --- | --- | --- |
 | name |  str |  | The name of the model (the name of the .prefab file, minus the extension). |
 | output_directory |  Union[str, Path] |  | The root output directory as a string or [`Path`](https://docs.python.org/3/library/pathlib.html). If this directory doesn't exist, it will be created. |
+| targets |  List[str] | None | A list of build targets. Options: "linux", "osx", "windows", "webgl". If None, defaults to `["linux", "osx", "windows"]`. |
 
 #### cleanup
 
@@ -145,6 +148,8 @@ _Returns:_  The name of the Unity C# class, e.g. `ModelCreator`.
 
 **`self.source_file_to_asset_bundles(name, source_file, output_directory)`**
 
+**`self.source_file_to_asset_bundles(name, source_file, output_directory, targets=None)`**
+
 Convert a source file into 3 asset bundle files (Windows, OS X, and Linux).
 
 | Parameter | Type | Default | Description |
@@ -152,12 +157,13 @@ Convert a source file into 3 asset bundle files (Windows, OS X, and Linux).
 | name |  str |  | The name of the animation. |
 | source_file |  Union[str, Path] |  | The path to the source file as a string or [`Path`](https://docs.python.org/3/library/pathlib.html). |
 | output_directory |  Union[str, Path] |  | The root output directory as a string or [`Path`](https://docs.python.org/3/library/pathlib.html). If this directory doesn't exist, it will be created. |
+| targets |  List[str] | None | A list of build targets. Options: "linux", "osx", "windows", "webgl". If None, defaults to `["linux", "osx", "windows"]`. |
 
 #### source_directory_to_asset_bundles
 
 **`self.source_directory_to_asset_bundles(source_directory, output_directory)`**
 
-**`self.source_directory_to_asset_bundles(source_directory, output_directory, library_description=None, overwrite=False, continue_on_error=True, search_pattern=None, cleanup=True)`**
+**`self.source_directory_to_asset_bundles(source_directory, output_directory, library_description=None, overwrite=False, continue_on_error=True, search_pattern=None, cleanup=True, targets=None)`**
 
 Convert a directory of source files to asset bundles.
 
@@ -172,3 +178,4 @@ Calling this is *significantly* faster than calling `self.source_file_to_asset_b
 | continue_on_error |  bool  | True | If True, continue generating asset bundles even if there is a problem with one file. If False, stop the process if there's an error. |
 | search_pattern |  str  | None | A search pattern for files, for example `"*.fbx"`. All subdirectories will be recursively searched. |
 | cleanup |  bool  | True | If True, delete intermediary files such as the prefabs in the `asset_bundle_creator` Unity Editor project. |
+| targets |  List[str] | None | A list of build targets. Options: "linux", "osx", "windows", "webgl". If None, defaults to `["linux", "osx", "windows"]`. |

--- a/Documentation/python/asset_bundle_creator/model_creator.md
+++ b/Documentation/python/asset_bundle_creator/model_creator.md
@@ -75,6 +75,8 @@ Execute a call to Unity Editor. If `self.quiet == False` this will continuously 
 
 **`self.prefab_to_asset_bundles(name, output_directory)`**
 
+**`self.prefab_to_asset_bundles(name, output_directory, targets=None)`**
+
 Build asset bundles from a .prefab file. This is useful when you want to edit the .prefab file by hand, e.g.:
 
 1. `self.source_file_to_prefab()`
@@ -112,6 +114,7 @@ output_directory/
 | --- | --- | --- | --- |
 | name |  str |  | The name of the model (the name of the .prefab file, minus the extension). |
 | output_directory |  Union[str, Path] |  | The root output directory as a string or [`Path`](https://docs.python.org/3/library/pathlib.html). If this directory doesn't exist, it will be created. |
+| targets |  List[str] | None | A list of build targets. Options: "linux", "osx", "windows", "webgl". If None, defaults to `["linux", "osx", "windows"]`. |
 
 #### cleanup
 
@@ -159,7 +162,7 @@ _Returns:_  The name of the Unity C# class, e.g. `ModelCreator`.
 
 **`self.source_file_to_asset_bundles(name, source_file, output_directory)`**
 
-**`self.source_file_to_asset_bundles(name, source_file, output_directory, vhacd_resolution=800000, internal_materials=False, wnid=None, wcategory=None, scale_factor=1, library_path=None, library_description=None, cleanup=True, write_physics_quality=False, validate=False)`**
+**`self.source_file_to_asset_bundles(name, source_file, output_directory, vhacd_resolution=800000, internal_materials=False, wnid=None, wcategory=None, scale_factor=1, library_path=None, library_description=None, cleanup=True, write_physics_quality=False, validate=False, targets=None)`**
 
 Convert a source .obj or .fbx file into 3 asset bundle files (Windows, OS X, and Linux).
 
@@ -215,12 +218,13 @@ library.json
 | cleanup |  bool  | True | If True, delete intermediary files such as the prefab in the `asset_bundle_creator` Unity Editor project. |
 | write_physics_quality |  bool  | False | If True, launch a controller and build to calculate the hull collider accuracy. Write the result to `output_directory/record.json` and to `library_path` if `library_path` is not None. |
 | validate |  bool  | False | If True, launch a controller and build to validate the model, checking it for any errors. Write the result to `output_directory/record.json` and to `library_path` if `library_path` is not None. |
+| targets |  List[str] | None | A list of build targets. Options: "linux", "osx", "windows", "webgl". If None, defaults to `["linux", "osx", "windows"]`. |
 
 #### source_directory_to_asset_bundles
 
 **`self.source_directory_to_asset_bundles(source_directory, output_directory)`**
 
-**`self.source_directory_to_asset_bundles(source_directory, output_directory, library_description=None, vhacd_resolution=800000, internal_materials=False, overwrite=False, continue_on_error=True, search_pattern=None, cleanup=True)`**
+**`self.source_directory_to_asset_bundles(source_directory, output_directory, library_description=None, vhacd_resolution=800000, internal_materials=False, overwrite=False, continue_on_error=True, search_pattern=None, cleanup=True, targets=None)`**
 
 Convert a directory of source .fbx and/or .obj models to asset bundles.
 
@@ -281,12 +285,13 @@ Note: This method does *not* call `self.write_physics_quality()` or `self.valida
 | continue_on_error |  bool  | True | If True, continue generating asset bundles even if there is a problem with one model. If False, stop the process if there's an error. |
 | search_pattern |  str  | None | A search pattern for files, for example `"*.obj"`. All subdirectories will be recursively searched. |
 | cleanup |  bool  | True | If True, delete intermediary files such as the prefabs in the `asset_bundle_creator` Unity Editor project. |
+| targets |  List[str] | None | A list of build targets. Options: "linux", "osx", "windows", "webgl". If None, defaults to `["linux", "osx", "windows"]`. |
 
 #### metadata_file_to_asset_bundles
 
 **`self.metadata_file_to_asset_bundles(metadata_path, output_directory)`**
 
-**`self.metadata_file_to_asset_bundles(metadata_path, output_directory, library_description=None, vhacd_resolution=800000, internal_materials=False, overwrite=False, continue_on_error=True, cleanup=True)`**
+**`self.metadata_file_to_asset_bundles(metadata_path, output_directory, library_description=None, vhacd_resolution=800000, internal_materials=False, overwrite=False, continue_on_error=True, cleanup=True, targets=None)`**
 
 Given a metadata .csv file within an output directory, generate asset bundles.
 
@@ -342,6 +347,7 @@ Note: This method does *not* call `self.write_physics_quality()` or `self.valida
 | overwrite |  bool  | False | If True, overwrite existing asset bundles. If this is set to False (the default value), you can stop/resume the processing of a directory's contents. |
 | continue_on_error |  bool  | True | If True, continue generating asset bundles even if there is a problem with one model. If False, stop the process if there's an error. |
 | cleanup |  bool  | True | If True, delete intermediary files such as the prefabs in the `asset_bundle_creator` Unity Editor project. |
+| targets |  List[str] | None | A list of build targets. Options: "linux", "osx", "windows", "webgl". If None, defaults to `["linux", "osx", "windows"]`. |
 
 #### source_file_to_prefab
 

--- a/Documentation/python/asset_bundle_creator/robot_creator.md
+++ b/Documentation/python/asset_bundle_creator/robot_creator.md
@@ -64,6 +64,8 @@ Execute a call to Unity Editor. If `self.quiet == False` this will continuously 
 
 **`self.prefab_to_asset_bundles(name, output_directory)`**
 
+**`self.prefab_to_asset_bundles(name, output_directory, targets=None)`**
+
 Build asset bundles from a .prefab file. This is useful when you want to edit the .prefab file by hand, e.g.:
 
 1. `self.source_file_to_prefab()`
@@ -101,6 +103,7 @@ output_directory/
 | --- | --- | --- | --- |
 | name |  str |  | The name of the model (the name of the .prefab file, minus the extension). |
 | output_directory |  Union[str, Path] |  | The root output directory as a string or [`Path`](https://docs.python.org/3/library/pathlib.html). If this directory doesn't exist, it will be created. |
+| targets |  List[str] | None | A list of build targets. Options: "linux", "osx", "windows", "webgl". If None, defaults to `["linux", "osx", "windows"]`. |
 
 #### cleanup
 
@@ -148,7 +151,7 @@ _Returns:_  The name of the Unity C# class, e.g. `ModelCreator`.
 
 **`self.source_url_to_asset_bundles(url, output_directory)`**
 
-**`self.source_url_to_asset_bundles(url, output_directory, required_repo_urls=None, xacro_args=None, immovable=True, description_infix=None, branch=None, library_path=None, library_description=None, source_description=None)`**
+**`self.source_url_to_asset_bundles(url, output_directory, required_repo_urls=None, xacro_args=None, immovable=True, description_infix=None, branch=None, library_path=None, library_description=None, source_description=None, targets=None)`**
 
 Given the URL of a .urdf file or a .xacro file, create asset bundles of the robot.
 
@@ -200,12 +203,13 @@ output_directory/
 | library_path |  Union[str, Path] | None | If not None, this is a path as a string or [`Path`](https://docs.python.org/3/library/pathlib.html) to a new or existing `RobotLibrarian` .json file. The record will be added to this file in addition to being saved to `record.json`. |
 | library_description |  str  | None | A description of the library. Ignored if `library_path` is None. |
 | source_description |  str  | None | A description of the source of the .urdf file, for example the repo URL. |
+| targets |  List[str] | None | A list of build targets. Options: "linux", "osx", "windows", "webgl". If None, defaults to `["linux", "osx", "windows"]`. |
 
 #### source_file_to_asset_bundles
 
 **`self.source_file_to_asset_bundles(source_file, output_directory)`**
 
-**`self.source_file_to_asset_bundles(source_file, output_directory, immovable=True, library_path=None, library_description=None, source_description=None)`**
+**`self.source_file_to_asset_bundles(source_file, output_directory, immovable=True, library_path=None, library_description=None, source_description=None, targets=None)`**
 
 Given a .urdf file plus its meshes, create asset bundles of the robot.
 
@@ -266,6 +270,7 @@ output_directory/
 | library_path |  Union[str, Path] | None | If not None, this is a path as a string or [`Path`](https://docs.python.org/3/library/pathlib.html) to a new or existing `RobotLibrarian` .json file. The record will be added to this file in addition to being saved to `record.json`. |
 | library_description |  str  | None | A description of the library. Ignored if `library_path` is None. |
 | source_description |  str  | None | A description of the source of the .urdf file, for example the repo URL. |
+| targets |  List[str] | None | A list of build targets. Options: "linux", "osx", "windows", "webgl". If None, defaults to `["linux", "osx", "windows"]`. |
 
 #### clone_repo
 

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from pathlib import Path
 import re
 
-__version__ = "1.12.11.0"
+__version__ = "1.12.11.1"
 readme_path = Path('../README.md')
 if readme_path.exists():
     long_description = readme_path.read_text(encoding='utf-8')

--- a/Python/tdw/asset_bundle_creator/composite_object_creator.py
+++ b/Python/tdw/asset_bundle_creator/composite_object_creator.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Union
+from typing import Union, List
 from tdw.asset_bundle_creator.asset_bundle_creator import AssetBundleCreator
 
 
@@ -14,7 +14,7 @@ class CompositeObjectCreator(AssetBundleCreator):
 
     def source_file_to_asset_bundles(self, name: str, source_file: Union[str, Path], output_directory: Union[str, Path],
                                      vhacd_resolution: int = 800000, wnid: str = None, wcategory: str = None,
-                                     cleanup: bool = True) -> None:
+                                     cleanup: bool = True, targets: List[str] = None) -> None:
         """
         Convert a source .urdf file into 3 asset bundle files (Windows, OS X, and Linux).
 
@@ -59,6 +59,7 @@ class CompositeObjectCreator(AssetBundleCreator):
         :param wnid: The WordNet ID of the model. Can be None.
         :param wcategory: The WordNet category of the model. Can be None.
         :param cleanup: If True, delete intermediary files such as the prefab in the `asset_bundle_creator` Unity Editor project.
+        :param targets: A list of build targets. Options: "linux", "osx", "windows", "webgl". If None, defaults to `["linux", "osx", "windows"]`.
         """
 
         args = CompositeObjectCreator._get_source_destination_args(name=name, source=source_file, destination=output_directory)
@@ -68,6 +69,7 @@ class CompositeObjectCreator(AssetBundleCreator):
                 args.append(f'-{flag}="{value}"')
         if cleanup:
             args.append("-cleanup")
+        args = AssetBundleCreator._add_target_args(args=args, targets=targets)
         self.call_unity(method="SourceFileToAssetBundles",
                         args=args,
                         log_path=AssetBundleCreator._get_log_path(output_directory))

--- a/Python/tdw/asset_bundle_creator/humanoid_creator_base.py
+++ b/Python/tdw/asset_bundle_creator/humanoid_creator_base.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import Union
+from typing import Union, List
 from pathlib import Path
 from overrides import final
 from tdw.tdw_utils import TDWUtils
@@ -12,16 +12,19 @@ class HumanoidCreatorBase(AssetBundleCreator, ABC):
     """
 
     @final
-    def source_file_to_asset_bundles(self, name: str, source_file: Union[str, Path], output_directory: Union[str, Path]) -> None:
+    def source_file_to_asset_bundles(self, name: str, source_file: Union[str, Path], output_directory: Union[str, Path],
+                                     targets: List[str] = None) -> None:
         """
         Convert a source file into 3 asset bundle files (Windows, OS X, and Linux).
 
         :param name: The name of the animation.
         :param source_file: The path to the source file as a string or [`Path`](https://docs.python.org/3/library/pathlib.html).
         :param output_directory: The root output directory as a string or [`Path`](https://docs.python.org/3/library/pathlib.html). If this directory doesn't exist, it will be created.
+        :param targets: A list of build targets. Options: "linux", "osx", "windows", "webgl". If None, defaults to `["linux", "osx", "windows"]`.
         """
 
         args = HumanoidCreatorBase._get_source_destination_args(name=name, source=source_file, destination=output_directory)
+        args = AssetBundleCreator._add_target_args(args=args, targets=targets)
         self.call_unity(method="SourceFileToAssetBundles",
                         args=args,
                         log_path=AssetBundleCreator._get_log_path(output_directory))
@@ -29,7 +32,7 @@ class HumanoidCreatorBase(AssetBundleCreator, ABC):
     @final
     def source_directory_to_asset_bundles(self, source_directory: Union[str, Path], output_directory: Union[str, Path],
                                           library_description: str = None, overwrite: bool = False, continue_on_error: bool = True,
-                                          search_pattern: str = None, cleanup: bool = True) -> None:
+                                          search_pattern: str = None, cleanup: bool = True, targets: List[str] = None) -> None:
         """
         Convert a directory of source files to asset bundles.
 
@@ -42,6 +45,7 @@ class HumanoidCreatorBase(AssetBundleCreator, ABC):
         :param continue_on_error: If True, continue generating asset bundles even if there is a problem with one file. If False, stop the process if there's an error.
         :param search_pattern: A search pattern for files, for example `"*.fbx"`. All subdirectories will be recursively searched.
         :param cleanup: If True, delete intermediary files such as the prefabs in the `asset_bundle_creator` Unity Editor project.
+        :param targets: A list of build targets. Options: "linux", "osx", "windows", "webgl". If None, defaults to `["linux", "osx", "windows"]`.
         """
 
         args = [f'-source_directory="{TDWUtils.get_string_path(source_directory)}"',
@@ -55,6 +59,7 @@ class HumanoidCreatorBase(AssetBundleCreator, ABC):
             args.append("-continue_on_error")
         if cleanup:
             args.append("-cleanup")
+        args = AssetBundleCreator._add_target_args(args=args, targets=targets)
         self.call_unity(method="SourceDirectoryToAssetBundles",
                         args=args,
                         log_path=TDWUtils.get_path(output_directory).joinpath("progress.txt"))

--- a/Python/tdw/asset_bundle_creator/model_creator.py
+++ b/Python/tdw/asset_bundle_creator/model_creator.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Union
+from typing import Union, List
 import json
 from tdw.librarian import ModelRecord, ModelLibrarian
 from tdw.asset_bundle_creator.asset_bundle_creator import AssetBundleCreator
@@ -31,7 +31,8 @@ class ModelCreator(AssetBundleCreator):
                                      vhacd_resolution: int = 800000, internal_materials: bool = False,
                                      wnid: str = None, wcategory: str = None, scale_factor: float = 1,
                                      library_path: Union[str, Path] = None, library_description: str = None,
-                                     cleanup: bool = True, write_physics_quality: bool = False, validate: bool = False) -> None:
+                                     cleanup: bool = True, write_physics_quality: bool = False, validate: bool = False,
+                                     targets: List[str] = None) -> None:
         """
         Convert a source .obj or .fbx file into 3 asset bundle files (Windows, OS X, and Linux).
 
@@ -85,6 +86,7 @@ class ModelCreator(AssetBundleCreator):
         :param cleanup: If True, delete intermediary files such as the prefab in the `asset_bundle_creator` Unity Editor project.
         :param write_physics_quality: If True, launch a controller and build to calculate the hull collider accuracy. Write the result to `output_directory/record.json` and to `library_path` if `library_path` is not None.
         :param validate: If True, launch a controller and build to validate the model, checking it for any errors. Write the result to `output_directory/record.json` and to `library_path` if `library_path` is not None.
+        :param targets: A list of build targets. Options: "linux", "osx", "windows", "webgl". If None, defaults to `["linux", "osx", "windows"]`.
         """
 
         args = AssetBundleCreator._get_source_destination_args(name=name, source=source_file, destination=output_directory)
@@ -96,6 +98,7 @@ class ModelCreator(AssetBundleCreator):
         args = AssetBundleCreator._add_library_args(args=args,
                                                     library_path=library_path,
                                                     library_description=library_description)
+        args = AssetBundleCreator._add_target_args(args=args, targets=targets)
         for value, flag in zip([internal_materials, cleanup], ["-internal_materials", "-cleanup"]):
             if value:
                 args.append(flag)
@@ -118,7 +121,7 @@ class ModelCreator(AssetBundleCreator):
                                           library_description: str = None,  vhacd_resolution: int = 800000,
                                           internal_materials: bool = False, overwrite: bool = False,
                                           continue_on_error: bool = True, search_pattern: str = None,
-                                          cleanup: bool = True) -> None:
+                                          cleanup: bool = True, targets: List[str] = None) -> None:
         """
         Convert a directory of source .fbx and/or .obj models to asset bundles.
 
@@ -177,12 +180,14 @@ class ModelCreator(AssetBundleCreator):
         :param continue_on_error: If True, continue generating asset bundles even if there is a problem with one model. If False, stop the process if there's an error.
         :param search_pattern: A search pattern for files, for example `"*.obj"`. All subdirectories will be recursively searched.
         :param cleanup: If True, delete intermediary files such as the prefabs in the `asset_bundle_creator` Unity Editor project.
+        :param targets: A list of build targets. Options: "linux", "osx", "windows", "webgl". If None, defaults to `["linux", "osx", "windows"]`.
         """
 
         args = [f'-source_directory="{TDWUtils.get_string_path(source_directory)}"',
                 f'-output_directory="{TDWUtils.get_string_path(output_directory)}"',
                 f'-vhacd_resolution={vhacd_resolution}']
         args = AssetBundleCreator._add_library_args(args=args, library_description=library_description)
+        args = AssetBundleCreator._add_target_args(args=args, targets=targets)
         if search_pattern is not None:
             args.append(f'-search_pattern="{search_pattern}"')
         if internal_materials:
@@ -200,7 +205,8 @@ class ModelCreator(AssetBundleCreator):
     def metadata_file_to_asset_bundles(self, metadata_path: Union[str, Path], output_directory: Union[str, Path],
                                        library_description: str = None, vhacd_resolution: int = 800000,
                                        internal_materials: bool = False, overwrite: bool = False,
-                                       continue_on_error: bool = True, cleanup: bool = True) -> None:
+                                       continue_on_error: bool = True, cleanup: bool = True,
+                                       targets: List[str] = None) -> None:
         """
         Given a metadata .csv file within an output directory, generate asset bundles.
 
@@ -254,12 +260,14 @@ class ModelCreator(AssetBundleCreator):
         :param overwrite: If True, overwrite existing asset bundles. If this is set to False (the default value), you can stop/resume the processing of a directory's contents.
         :param continue_on_error: If True, continue generating asset bundles even if there is a problem with one model. If False, stop the process if there's an error.
         :param cleanup: If True, delete intermediary files such as the prefabs in the `asset_bundle_creator` Unity Editor project.
+        :param targets: A list of build targets. Options: "linux", "osx", "windows", "webgl". If None, defaults to `["linux", "osx", "windows"]`.
         """
 
         args = [f'-metadata_path={TDWUtils.get_string_path(metadata_path)}',
                 f'-output_directory="{TDWUtils.get_string_path(output_directory)}"',
                 f'-vhacd_resolution={vhacd_resolution}']
         args = AssetBundleCreator._add_library_args(args=args, library_description=library_description)
+        args = AssetBundleCreator._add_target_args(args=args, targets=targets)
         if internal_materials:
             args.append("-internal_materials")
         if overwrite:

--- a/Python/tdw/asset_bundle_creator/robot_creator.py
+++ b/Python/tdw/asset_bundle_creator/robot_creator.py
@@ -24,7 +24,7 @@ class RobotCreator(AssetBundleCreator):
                                     xacro_args: Dict[str, str] = None, immovable: bool = True,
                                     description_infix: str = None, branch: str = None,
                                     library_path: Union[str, Path] = None, library_description: str = None,
-                                    source_description: str = None) -> None:
+                                    source_description: str = None, targets: List[str] = None) -> None:
         """
         Given the URL of a .urdf file or a .xacro file, create asset bundles of the robot.
 
@@ -74,6 +74,7 @@ class RobotCreator(AssetBundleCreator):
         :param library_path: If not None, this is a path as a string or [`Path`](https://docs.python.org/3/library/pathlib.html) to a new or existing `RobotLibrarian` .json file. The record will be added to this file in addition to being saved to `record.json`.
         :param library_description: A description of the library. Ignored if `library_path` is None.
         :param source_description: A description of the source of the .urdf file, for example the repo URL.
+        :param targets: A list of build targets. Options: "linux", "osx", "windows", "webgl". If None, defaults to `["linux", "osx", "windows"]`.
         """
 
         if required_repo_urls is None:
@@ -100,11 +101,12 @@ class RobotCreator(AssetBundleCreator):
         self.source_file_to_asset_bundles(source_file=urdf_path, output_directory=output_directory,
                                           immovable=immovable, library_path=library_path,
                                           library_description=library_description,
-                                          source_description=source_description)
+                                          source_description=source_description, targets=targets)
 
     def source_file_to_asset_bundles(self, source_file: Union[str, Path], output_directory: Union[str, Path],
                                      immovable: bool = True, library_path: Union[str, Path] = None,
-                                     library_description: str = None, source_description: str = None) -> None:
+                                     library_description: str = None, source_description: str = None,
+                                     targets: List[str] = None) -> None:
         """
         Given a .urdf file plus its meshes, create asset bundles of the robot.
 
@@ -163,6 +165,7 @@ class RobotCreator(AssetBundleCreator):
         :param library_path: If not None, this is a path as a string or [`Path`](https://docs.python.org/3/library/pathlib.html) to a new or existing `RobotLibrarian` .json file. The record will be added to this file in addition to being saved to `record.json`.
         :param library_description: A description of the library. Ignored if `library_path` is None.
         :param source_description: A description of the source of the .urdf file, for example the repo URL.
+        :param targets: A list of build targets. Options: "linux", "osx", "windows", "webgl". If None, defaults to `["linux", "osx", "windows"]`.
         """
 
         args = self._get_source_destination_args(name=RobotCreator.get_name(source_file),
@@ -175,6 +178,7 @@ class RobotCreator(AssetBundleCreator):
         args = AssetBundleCreator._add_library_args(args=args,
                                                     library_path=library_path,
                                                     library_description=library_description)
+        args = AssetBundleCreator._add_target_args(args=args, targets=targets)
         self.call_unity(method="SourceFileToAssetBundles",
                         args=args,
                         log_path=AssetBundleCreator._get_log_path(output_directory))


### PR DESCRIPTION
Added optional argument `targets` to each asset bundle creator (e.g. `ModelCreator`) function that creates asset bundles (e.g. `source_file_to_asset_bundles()`). If set, asset bundles for only these targets will be created. Options: `"linux"`, `"osx"`, `"windows"`, `"webgl"`. If None, defaults to `["linux", "osx", "windows"]`.