### PR TITLE
Fixed: The argument parser in Controller allows ambiguous abbreviations.

### DIFF
--- a/Documentation/Changelog.md
+++ b/Documentation/Changelog.md
@@ -19,6 +19,7 @@ To upgrade from TDW v1.11 to v1.12, read [this guide](upgrade_guides/v1.11_to_v1
 - Added: `AddOn.get_early_initialization_commands()`. These commands are inserted before all others. Most add-ons shouldn't override this function; it's only useful for cases where the add-on *must* execute first, e.g. a loading screen.
 - Added new "UI Widgets", subclasses of `UI`, to `tdw.add_ons.ui_widgets`: `LoadingScreen`, `ProgressBar`, and `TimerBar`.
 - Moved `UI.add_loading_screen()` to the new `LoadingScreen` UI widget add-on.
+- Fixed: The argument parser in `Controller` allows ambiguous abbreviations.
 
 ### Documentation
 

--- a/Python/tdw/controller.py
+++ b/Python/tdw/controller.py
@@ -568,10 +568,11 @@ class Controller:
         :param port: The socket port.
         """
 
-        parser = ArgumentParser()
+        parser = ArgumentParser(allow_abbrev=False)
         parser.add_argument("--flip_images", action="store_true")
         parser.add_argument("--force_glcore42", action="store_true")
         args, unknown = parser.parse_known_args()
+        print("ARGS", args, unknown)
         build_call = [str(BUILD_PATH.resolve()), "-port " + str(port)]
         if args.flip_images:
             build_call.append("-flip_images")

--- a/Python/tdw/controller.py
+++ b/Python/tdw/controller.py
@@ -572,7 +572,6 @@ class Controller:
         parser.add_argument("--flip_images", action="store_true")
         parser.add_argument("--force_glcore42", action="store_true")
         args, unknown = parser.parse_known_args()
-        print("ARGS", args, unknown)
         build_call = [str(BUILD_PATH.resolve()), "-port " + str(port)]
         if args.flip_images:
             build_call.append("-flip_images")


### PR DESCRIPTION
Closes #654