### PR TITLE
Gaze hit positions

### DIFF
--- a/Python/example_controllers/vr/fove_calibration_test.py
+++ b/Python/example_controllers/vr/fove_calibration_test.py
@@ -48,11 +48,7 @@ five_pnt_z_pos = [g1_z, g1_z, g1_z, g1_z, g1_z, g2_z, g2_z, g2_z, g2_z, g2_z, g3
 sphere_ids = []
 sphere_ids_static = []
 touch_time = 0.5
-eye_data: Dict[int, float] = dict()
-finger_data: Dict[int, Transform] = dict()
 timer_started = False
-gaze_depth_list = []
-finger_pos_list = []
 array = np.zeros(shape=(2, 15, 3))
 saved_data = False
 
@@ -102,8 +98,8 @@ while not vr.done:
                 insert_position(False, sphere_ids_static.index(sphere_id), vr.right_hand_transforms[bone].position)
             else:
                 # User touched this sphere for the defined duration, so end touch event and remove sphere ID from use.
-                commands.append({"$type": "set_object_visibility", "id": sphere_id, "visible": False})
-                print("Completed sphere " + str(sphere_id))
+                #commands.append({"$type": "set_object_visibility", "id": sphere_id, "visible": False})
+                commands.append({"$type": "hide_object", "id": sphere_id})
                 sphere_ids.remove(sphere_id)
                 #gaze_depth_list.clear()              
                 timer_started = False

--- a/Python/example_controllers/vr/fove_calibration_test.py
+++ b/Python/example_controllers/vr/fove_calibration_test.py
@@ -39,10 +39,10 @@ g3_z = -0.4
 xlt = -0.125
 xmid = 0
 xrt = 0.125
-yup = 1.1
-ymid = 1.0
-ylow = 0.9
-five_pnt_x_pos = [xlt, xmid, xrt, xlt, xrt, xlt - 0.0175, xmid, xrt + 0.0175, xlt - 0.0175, xrt + 0.0175, xlt - 0.025, xmid, xrt + 0.025, xlt - 0.025, xrt + 0.025]
+yup = 0.9
+ymid = 0.8
+ylow = 0.7
+five_pnt_x_pos = [xlt, xmid, xrt, xlt, xrt, xlt + 0.0175, xmid, xrt - 0.0175, xlt + 0.0175, xrt - 0.0175, xlt + 0.025, xmid, xrt - 0.025, xlt + 0.025, xrt - 0.025]
 five_pnt_y_pos = [yup, ymid, ylow, ylow, yup, yup, ymid, ylow, ylow, yup, yup, ymid, ylow, ylow, yup]
 five_pnt_z_pos = [g1_z, g1_z, g1_z, g1_z, g1_z, g2_z, g2_z, g2_z, g2_z, g2_z, g3_z, g3_z, g3_z, g3_z, g3_z]
 sphere_ids = []
@@ -54,6 +54,7 @@ timer_started = False
 gaze_depth_list = []
 finger_pos_list = []
 array = np.zeros(shape=(2, 15, 3))
+saved_data = False
 
 commands = []
 # Create sphere groups 1-3.
@@ -102,6 +103,7 @@ while not vr.done:
             else:
                 # User touched this sphere for the defined duration, so end touch event and remove sphere ID from use.
                 commands.append({"$type": "set_object_visibility", "id": sphere_id, "visible": False})
+                print("Completed sphere " + str(sphere_id))
                 sphere_ids.remove(sphere_id)
                 #gaze_depth_list.clear()              
                 timer_started = False
@@ -114,6 +116,9 @@ while not vr.done:
     if (len(sphere_ids)) == 0:
         # All spheres have been touched, so write out the stored data array. 
         # If we do the averaging, we would do it here.
-        np.save("arr", array)
+        if not saved_data:
+            with open('C:\\Users\\weiwe\\OneDrive\\Documents\\eye_hand_data\\arr_' + str(time.time()) + ".npy", 'wb') as f:
+                np.save(f, array)
+                saved_data = True
 
 c.communicate({"$type": "terminate"})

--- a/Python/example_controllers/vr/fove_calibration_test.py
+++ b/Python/example_controllers/vr/fove_calibration_test.py
@@ -84,7 +84,6 @@ while not vr.done:
                 if timer_started == False: 
                     start_time = time.time()
                     timer_started = True
-                    #gaze_depth_list.clear()
                 break
         if touching:
             if timer_started:
@@ -98,10 +97,8 @@ while not vr.done:
                 insert_position(False, sphere_ids_static.index(sphere_id), vr.right_hand_transforms[bone].position)
             else:
                 # User touched this sphere for the defined duration, so end touch event and remove sphere ID from use.
-                #commands.append({"$type": "set_object_visibility", "id": sphere_id, "visible": False})
                 commands.append({"$type": "hide_object", "id": sphere_id})
-                sphere_ids.remove(sphere_id)
-                #gaze_depth_list.clear()              
+                sphere_ids.remove(sphere_id)              
                 timer_started = False
         else:
             # Reset color if sphere is still active and not being touched.

--- a/Python/tdw/FBOutput/Fove.py
+++ b/Python/tdw/FBOutput/Fove.py
@@ -63,7 +63,7 @@ class Fove(object):
         return 0
 
     # Fove
-    def ObjectHits(self, j):
+    def Hits(self, j):
         o = tdw.flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
         if o != 0:
             a = self._tab.Vector(o)
@@ -71,22 +71,44 @@ class Fove(object):
         return 0
 
     # Fove
-    def ObjectHitsAsNumpy(self):
+    def HitsAsNumpy(self):
         o = tdw.flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
         if o != 0:
             return self._tab.GetVectorAsNumpy(tdw.flatbuffers.number_types.BoolFlags, o)
         return 0
 
     # Fove
-    def ObjectHitsLength(self):
+    def HitsLength(self):
         o = tdw.flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
         if o != 0:
             return self._tab.VectorLen(o)
         return 0
 
     # Fove
-    def ObjectIds(self, j):
+    def ObjectHits(self, j):
         o = tdw.flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
+        if o != 0:
+            a = self._tab.Vector(o)
+            return self._tab.Get(tdw.flatbuffers.number_types.BoolFlags, a + tdw.flatbuffers.number_types.UOffsetTFlags.py_type(j * 1))
+        return 0
+
+    # Fove
+    def ObjectHitsAsNumpy(self):
+        o = tdw.flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
+        if o != 0:
+            return self._tab.GetVectorAsNumpy(tdw.flatbuffers.number_types.BoolFlags, o)
+        return 0
+
+    # Fove
+    def ObjectHitsLength(self):
+        o = tdw.flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
+        if o != 0:
+            return self._tab.VectorLen(o)
+        return 0
+
+    # Fove
+    def ObjectIds(self, j):
+        o = tdw.flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
         if o != 0:
             a = self._tab.Vector(o)
             return self._tab.Get(tdw.flatbuffers.number_types.Int32Flags, a + tdw.flatbuffers.number_types.UOffsetTFlags.py_type(j * 4))
@@ -94,33 +116,59 @@ class Fove(object):
 
     # Fove
     def ObjectIdsAsNumpy(self):
-        o = tdw.flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
+        o = tdw.flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
         if o != 0:
             return self._tab.GetVectorAsNumpy(tdw.flatbuffers.number_types.Int32Flags, o)
         return 0
 
     # Fove
     def ObjectIdsLength(self):
-        o = tdw.flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
+        o = tdw.flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
+        if o != 0:
+            return self._tab.VectorLen(o)
+        return 0
+
+    # Fove
+    def HitPositions(self, j):
+        o = tdw.flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(14))
+        if o != 0:
+            a = self._tab.Vector(o)
+            return self._tab.Get(tdw.flatbuffers.number_types.Float32Flags, a + tdw.flatbuffers.number_types.UOffsetTFlags.py_type(j * 4))
+        return 0
+
+    # Fove
+    def HitPositionsAsNumpy(self):
+        o = tdw.flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(14))
+        if o != 0:
+            return self._tab.GetVectorAsNumpy(tdw.flatbuffers.number_types.Float32Flags, o)
+        return 0
+
+    # Fove
+    def HitPositionsLength(self):
+        o = tdw.flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(14))
         if o != 0:
             return self._tab.VectorLen(o)
         return 0
 
     # Fove
     def CombinedDepth(self):
-        o = tdw.flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
+        o = tdw.flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(16))
         if o != 0:
             return self._tab.Get(tdw.flatbuffers.number_types.Float32Flags, o + self._tab.Pos)
         return 0.0
 
-def FoveStart(builder): builder.StartObject(5)
+def FoveStart(builder): builder.StartObject(7)
 def FoveAddEyeDirections(builder, eyeDirections): builder.PrependUOffsetTRelativeSlot(0, tdw.flatbuffers.number_types.UOffsetTFlags.py_type(eyeDirections), 0)
 def FoveStartEyeDirectionsVector(builder, numElems): return builder.StartVector(4, numElems, 4)
 def FoveAddEyeStates(builder, eyeStates): builder.PrependUOffsetTRelativeSlot(1, tdw.flatbuffers.number_types.UOffsetTFlags.py_type(eyeStates), 0)
 def FoveStartEyeStatesVector(builder, numElems): return builder.StartVector(1, numElems, 1)
-def FoveAddObjectHits(builder, objectHits): builder.PrependUOffsetTRelativeSlot(2, tdw.flatbuffers.number_types.UOffsetTFlags.py_type(objectHits), 0)
+def FoveAddHits(builder, hits): builder.PrependUOffsetTRelativeSlot(2, tdw.flatbuffers.number_types.UOffsetTFlags.py_type(hits), 0)
+def FoveStartHitsVector(builder, numElems): return builder.StartVector(1, numElems, 1)
+def FoveAddObjectHits(builder, objectHits): builder.PrependUOffsetTRelativeSlot(3, tdw.flatbuffers.number_types.UOffsetTFlags.py_type(objectHits), 0)
 def FoveStartObjectHitsVector(builder, numElems): return builder.StartVector(1, numElems, 1)
-def FoveAddObjectIds(builder, objectIds): builder.PrependUOffsetTRelativeSlot(3, tdw.flatbuffers.number_types.UOffsetTFlags.py_type(objectIds), 0)
+def FoveAddObjectIds(builder, objectIds): builder.PrependUOffsetTRelativeSlot(4, tdw.flatbuffers.number_types.UOffsetTFlags.py_type(objectIds), 0)
 def FoveStartObjectIdsVector(builder, numElems): return builder.StartVector(4, numElems, 4)
-def FoveAddCombinedDepth(builder, combinedDepth): builder.PrependFloat32Slot(4, combinedDepth, 0.0)
+def FoveAddHitPositions(builder, hitPositions): builder.PrependUOffsetTRelativeSlot(5, tdw.flatbuffers.number_types.UOffsetTFlags.py_type(hitPositions), 0)
+def FoveStartHitPositionsVector(builder, numElems): return builder.StartVector(4, numElems, 4)
+def FoveAddCombinedDepth(builder, combinedDepth): builder.PrependFloat32Slot(6, combinedDepth, 0.0)
 def FoveEnd(builder): return builder.EndObject()

--- a/Python/tdw/add_ons/fove_leap_motion.py
+++ b/Python/tdw/add_ons/fove_leap_motion.py
@@ -120,4 +120,5 @@ class FoveLeapMotion(LeapMotion):
 
         return Eye(state=EyeState.converged if converged else fove.get_eye_state(index),
                    direction=fove.get_eye_direction(index),
-                   gaze_id=fove.get_object_id(index) if fove.get_object_hit(index) else None)
+                   gaze_id=fove.get_object_id(index) if fove.get_object_hit(index) else None,
+                   gaze_position=fove.get_hit_position(index) if fove.get_hit(index) else None)

--- a/Python/tdw/output_data.py
+++ b/Python/tdw/output_data.py
@@ -1783,8 +1783,10 @@ class Fove(OutputData):
         super().__init__(b)
         self._eye_directions: np.ndarray = self.data.EyeDirectionsAsNumpy().reshape((3, 3))
         self._eye_states: np.ndarray = self.data.EyeStatesAsNumpy()
+        self._hits: np.ndarray = self.data.HitsAsNumpy()
         self._object_hits: np.ndarray = self.data.ObjectHitsAsNumpy()
         self._object_ids: np.ndarray = self.data.ObjectIdsAsNumpy()
+        self._hit_postions: np.ndarray = self.data.HitPositionsAsNumpy().reshape((3, 3))
 
     def get_data(self) -> Fov.Fove:
         return Fov.Fove.GetRootAsFove(self.bytes, 0)
@@ -1795,11 +1797,17 @@ class Fove(OutputData):
     def get_eye_state(self, index: int) -> EyeState:
         return EyeState(self._eye_states[index])
 
+    def get_hit(self, index: int) -> bool:
+        return bool(self._hits[index])
+
     def get_object_hit(self, index: int) -> bool:
         return bool(self._object_hits[index])
 
     def get_object_id(self, index: int) -> int:
         return int(self._object_ids[index])
+
+    def get_hit_position(self, index: int) -> np.ndarray:
+        return self._hit_postions[index]
 
     def get_combined_depth(self) -> float:
         return self.data.CombinedDepth()

--- a/Python/tdw/vr_data/fove/eye.py
+++ b/Python/tdw/vr_data/fove/eye.py
@@ -31,4 +31,4 @@ class Eye:
         """:field
         The position hit by the eye's ray. The ray can hit either an object or a scene mesh. Can be None.
         """
-        self.gaze_id: gaze_position[np.ndarray] = gaze_position
+        self.gaze_position: gaze_position[np.ndarray] = gaze_position

--- a/Python/tdw/vr_data/fove/eye.py
+++ b/Python/tdw/vr_data/fove/eye.py
@@ -8,11 +8,12 @@ class Eye:
     FOVE eye data.
     """
 
-    def __init__(self, state: EyeState, direction: np.ndarray, gaze_id: Optional[int]):
+    def __init__(self, state: EyeState, direction: np.ndarray, gaze_id: Optional[int], gaze_position: Optional[np.ndarray]):
         """
         :param state: The state of the eye: not_connected, opened, or closed.
         :param direction: Where the eye is looking.
         :param gaze_id: The ID of the object that the eye is gazing at. Can be None.
+        :param gaze_position: The position hit by the eye's ray. The ray can hit either an object or a scene mesh. Can be None.
         """
 
         """:field
@@ -27,3 +28,7 @@ class Eye:
         The ID of the object that the eye is gazing at. Can be None.
         """
         self.gaze_id: Optional[int] = gaze_id
+        """:field
+        The position hit by the eye's ray. The ray can hit either an object or a scene mesh. Can be None.
+        """
+        self.gaze_id: gaze_position[np.ndarray] = gaze_position

--- a/Python/tdw/vr_data/fove/fove_status.py
+++ b/Python/tdw/vr_data/fove/fove_status.py
@@ -1,0 +1,15 @@
+from enum import Enum
+
+
+class FoveStatus(Enum):
+    """
+    The status of the Fove re:calibration and trials.
+    """
+
+    fove_spiral = 0  # Running the FOVE spiral calibration.
+    eye_hand = 1  # Performing the sphere touch calibration protocol.
+    waiting_for_trigger = 2  # Listening on the port for the hardware trigger.
+    trial_ongoing = 3  # Received trigger. Trial has begun and is in process.
+    trial_success = 4  # Trial completed successfully.
+    trial_failure = 5  # Trial failed.
+


### PR DESCRIPTION
This PR merges `fove_hit_positions` into `fove_vr_calibration`, as opposed to `master`.

The changes in this PR have not been tested and require testing.

Added to `gaze_position` to `Eye` class. This is an x, y, z numpy array of the hit position of the eye's ray. The position is valid as long as the eye is looking at an object or a background scene mesh. If the eye is looking at empty space, `gaze_position` is None.